### PR TITLE
Update view and config file to support latest @editorjs/list block

### DIFF
--- a/config/laravel_editorjs.php
+++ b/config/laravel_editorjs.php
@@ -17,7 +17,7 @@ return [
                 'level' => [1, 2, 3, 4, 5, 6],
             ],
             'list'      => [
-                'type'  => [
+                'style'  => [
                     0 => 'ordered',
                     1 => 'unordered',
                 ],

--- a/resources/views/blocks/list.blade.php
+++ b/resources/views/blocks/list.blade.php
@@ -1,10 +1,6 @@
 @php
-$tag = 'ul';
-if (isset($data['style']) && 'ordered' === $data['style']) {
-    $tag = 'ol';
-} elseif (isset($data['type']) && 'ordered' === $data['type']) {
-    $tag = 'ol';
-}
+$listType = $data['style'] ?? $data['type'] ?? 'unordered';
+$tag = $listType === 'unordered' ? 'ul' : 'ol';
 @endphp
 
 <{{ $tag }}>

--- a/resources/views/blocks/list.blade.php
+++ b/resources/views/blocks/list.blade.php
@@ -1,7 +1,9 @@
 @php
 $tag = 'ul';
-if('ordered' === $data['style']){
-$tag = 'ol';
+if (isset($data['style']) && 'ordered' === $data['style']) {
+    $tag = 'ol';
+} elseif (isset($data['type']) && 'ordered' === $data['type']) {
+    $tag = 'ol';
 }
 @endphp
 

--- a/resources/views/blocks/list.blade.php
+++ b/resources/views/blocks/list.blade.php
@@ -1,6 +1,6 @@
 @php
 $tag = 'ul';
-if('ordered' === $data['type']){
+if('ordered' === $data['style']){
 $tag = 'ol';
 }
 @endphp


### PR DESCRIPTION
This pull request is in response to a change in the @editorjs/list block. The latest version of @editorjs/list generates data with a style parameter, as shown below:

```json
{
    "id": "vQMrQPWD-O",
    "type": "list",
    "data": {
        "style": "unordered",
        "items": [
            "Item 1",
            "Item 2"
        ]
    }
}
```

To align with this new output format, the view and the config file have been updated to support the style parameter for list formatting.