### PR TITLE
[3.x] Add bem css class name 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.3', '8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.1', '8.2', '8.3', '8.4']
 
     steps:
       - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
 		}
 	],
 	"require": {
-		"php": "^7.3|^8.1|^8.2|^8.3|^8.4",
+		"php": "^8.1|^8.2|^8.3|^8.4",
 		"codex-team/editor.js": "v2.0.7",
 		"illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0"
 	},
 	"require-dev": {
-		"orchestra/testbench": "^6.0",
-		"phpunit/phpunit": "^9.5"
+		"orchestra/testbench": "^8.36",
+		"phpunit/phpunit": "^10.5"
 	},
 	"autoload": {
 		"psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd" bootstrap="vendor/autoload.php" cacheResultFile=".phpunit.cache/test-results" colors="true">
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit</directory>
-        </testsuite>
-        <testsuite name="Feature">
-            <directory suffix="Test.php">./tests/Feature</directory>
-        </testsuite>
-    </testsuites>
-
-    <coverage cacheDirectory=".phpunit.cache/code-coverage" processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
+<phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.4/phpunit.xsd" 
+    bootstrap="vendor/autoload.php" 
+    colors="true">
+	<testsuites>
+		<testsuite name="Unit">
+			<directory suffix="Test.php">./tests/Unit</directory>
+		</testsuite>
+		<testsuite name="Feature">
+			<directory suffix="Test.php">./tests/Feature</directory>
+		</testsuite>
+	</testsuites>
+	<source>
+		<include>
+			<directory suffix=".php">src</directory>
+		</include>
+	</source>
 </phpunit>

--- a/resources/views/blocks/checklist.blade.php
+++ b/resources/views/blocks/checklist.blade.php
@@ -1,8 +1,8 @@
-<ul>
+<ul class="editorjs-checklist">
     @foreach($data['items'] as $item)
-        <li>
-            <input type="checkbox" {{ $item['checked'] ? 'checked' : '' }} disabled>
-            <span>{!! $item['text'] !!}</span>
+        <li class="editorjs-checklist__item editorjs-checklist__item--{{ $item['checked'] ? 'checked' : 'unchecked' }}">
+            <input class="editorjs-checklist__checkbox" type="checkbox" {{ $item['checked'] ? 'checked' : '' }} disabled>
+            <span class="editorjs-checklist__text">{!! $item['text'] !!}</span>
         </li>
     @endforeach
 </ul>

--- a/resources/views/blocks/code.blade.php
+++ b/resources/views/blocks/code.blade.php
@@ -1,3 +1,3 @@
-<div class="editor-code">
-    <code class="code__content">{{ htmlspecialchars($data['code']) }}</code>
+<div class="editorjs-code">
+    <code class="editorjs-code__content">{{ htmlspecialchars($data['code']) }}</code>
 </div>

--- a/resources/views/blocks/delimiter.blade.php
+++ b/resources/views/blocks/delimiter.blade.php
@@ -1,1 +1,1 @@
-<div class="editor-delimiter" style="text-align: center;">***</div>
+<div class="editorjs-delimiter" style="text-align: center;">***</div>

--- a/resources/views/blocks/header.blade.php
+++ b/resources/views/blocks/header.blade.php
@@ -3,4 +3,4 @@ $level = $data['level'] ?? 1;
 $tag = "h{$level}";
 @endphp
 
-<{{ $tag }}>{{ $data['text'] ?? '' }}</{{ $tag }}>
+<{{ $tag }} class="editorjs-header editorjs-header--level-{{ $level }}">{{ $data['text'] ?? '' }}</{{ $tag }}>

--- a/resources/views/blocks/image.blade.php
+++ b/resources/views/blocks/image.blade.php
@@ -1,20 +1,20 @@
 @php
 $classes = '';
 if ($data['stretched']){
-$classes .= ' image--stretched';
+$classes .= ' editorjs-image--stretched';
 }
 if ($data['withBorder']){
-$classes .= ' image--bordered';
+$classes .= ' editorjs-image--bordered';
 }
 if ($data['withBackground']){
-$classes .= ' image--backgrounded';
+$classes .= ' editorjs-image--backgrounded';
 }
 @endphp
 
-<figure class="image {{ $classes }}">
-    <img src="{{ $data['file']['url'] }}" alt="{{ $data['caption'] ?: '' }}">
+<figure class="editorjs-image {{ $classes }}">
+    <img class="editorjs-image__media" src="{{ $data['file']['url'] }}" alt="{{ $data['caption'] ?: '' }}">
     @if (!empty($data['caption']))
-    <footer class="image-caption">
+    <footer class="editorjs-image__caption">
         {{ $data['caption'] }}
     </footer>
     @endif

--- a/resources/views/blocks/link-tool.blade.php
+++ b/resources/views/blocks/link-tool.blade.php
@@ -1,18 +1,18 @@
-<a class="embed-link" href="{{ $data['link'] }}" target="_blank" rel="nofollow">
+<a class="editorjs-link" href="{{ $data['link'] }}" target="_blank" rel="nofollow">
     @php $metaImageUrl = $data['meta']['image']['url'] ?? '' @endphp
     @if ($metaImageUrl)
-    <img class="embed-link__image" src="{{ $metaImageUrl }}">
+    <img class="editorjs-link__image" src="{{ $metaImageUrl }}">
     @endif
 
-    <div class="embed-link__title">
+    <div class="editorjs-link__title">
         {{ $data['meta']['title'] }}
     </div>
 
-    <div class="embed-link__description">
+    <div class="editorjs-link__description">
         {{ $data['meta']['description'] }}
     </div>
 
-    <span class="embed-link__domain">
+    <span class="editorjs-link__domain">
         {{ parse_url($data['link'], PHP_URL_HOST)}}
     </span>
 </a>

--- a/resources/views/blocks/list.blade.php
+++ b/resources/views/blocks/list.blade.php
@@ -3,8 +3,8 @@ $listType = $data['style'] ?? $data['type'] ?? 'unordered';
 $tag = $listType === 'unordered' ? 'ul' : 'ol';
 @endphp
 
-<{{ $tag }}>
+<{{ $tag }} class="editorjs-list editorjs-list--{{ $listType }}">
     @foreach($data['items'] as $item)
-    <li>{{ $item }}</li>
+    <li class="editorjs-list__item editorjs-list__item--{{ $loop->odd ? 'odd' : 'even' }}">{{ $item }}</li>
     @endforeach
 </{{ $tag }}>

--- a/resources/views/blocks/not-found.blade.php
+++ b/resources/views/blocks/not-found.blade.php
@@ -1,1 +1,1 @@
-<p style="color: red">{{ "{$type}: " . __('Block Not Found!') }}</p>
+<p class="editorjs-block-not-found" style="color: red">{{ "{$type}: " . __('Block Not Found!') }}</p>

--- a/resources/views/blocks/paragraph.blade.php
+++ b/resources/views/blocks/paragraph.blade.php
@@ -1,1 +1,1 @@
-<p>{{ $data['text'] }}</p>
+<p class="editorjs-paragraph">{{ $data['text'] }}</p>

--- a/resources/views/blocks/quote.blade.php
+++ b/resources/views/blocks/quote.blade.php
@@ -10,9 +10,9 @@ $class = 'text-right';
 }
 @endphp
 
-<blockquote class="editor-quote">
-    <p class="{{ $class }}">{{ $data['text'] }}</p>
+<blockquote class="editorjs-quote">
+    <p class="editorjs-quote__text {{ $class }}">{{ $data['text'] }}</p>
     @if (!empty($data['caption']))
-    <small class="{{ $class }}">— {{ $data['caption'] }}</small>
+    <small class="editorjs-quote__caption {{ $class }}">— {{ $data['caption'] }}</small>
     @endif
 </blockquote>

--- a/resources/views/blocks/raw.blade.php
+++ b/resources/views/blocks/raw.blade.php
@@ -1,4 +1,4 @@
-<div style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace;
+<div class="editorjs-raw" style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace;
  font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;">
     {{ $data['html'] }}
 </div>

--- a/resources/views/blocks/table.blade.php
+++ b/resources/views/blocks/table.blade.php
@@ -1,10 +1,10 @@
-<table class="table">
+<table class="editorjs-table">
     @foreach($data['content'] as $row)
-    <tr>
+    <tr class="editorjs-table__row">
         @php $tag = ($loop->first && $data['withHeadings']) ? 'th' : 'td'; @endphp
 
         @foreach($row as $cell)
-        <{{ $tag }}> {{ $cell }} </{{ $tag }}>
+        <{{ $tag }} class="editorjs-table__cell"> {{ $cell }} </{{ $tag }}>
         @endforeach
     </tr>
     @endforeach

--- a/tests/Feature/Blocks/ChecklistTest.php
+++ b/tests/Feature/Blocks/ChecklistTest.php
@@ -39,7 +39,7 @@ class ChecklistTest extends TestCase
         return '<ul> <li> <input type="checkbox" checked disabled> <span><a href="https://githuh.com/lmottasin" target="_blank" rel="noreferrer noopener">LINK</a></span> </li> <li> <input type="checkbox" disabled> <span><b>BOLD</b></span> </li> <li> <input type="checkbox" disabled> <span><i>ITALIC</i></span> </li> <li> <input type="checkbox" disabled> <span>PLAIN TEXT</span> </li> </ul>';
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function render_checklist_block_test(): void
     {
         //This replaces any sequence of whitespace (including tabs and newlines) with a single space,

--- a/tests/Feature/Blocks/ChecklistTest.php
+++ b/tests/Feature/Blocks/ChecklistTest.php
@@ -36,7 +36,7 @@ class ChecklistTest extends TestCase
 
     protected function getBlockHtml()
     {
-        return '<ul> <li> <input type="checkbox" checked disabled> <span><a href="https://githuh.com/lmottasin" target="_blank" rel="noreferrer noopener">LINK</a></span> </li> <li> <input type="checkbox" disabled> <span><b>BOLD</b></span> </li> <li> <input type="checkbox" disabled> <span><i>ITALIC</i></span> </li> <li> <input type="checkbox" disabled> <span>PLAIN TEXT</span> </li> </ul>';
+        return '<ul class="editorjs-checklist"> <li class="editorjs-checklist__item editorjs-checklist__item--checked"> <input class="editorjs-checklist__checkbox" type="checkbox" checked disabled> <span class="editorjs-checklist__text"><a href="https://githuh.com/lmottasin" target="_blank" rel="noreferrer noopener">LINK</a></span> </li> <li class="editorjs-checklist__item editorjs-checklist__item--unchecked"> <input class="editorjs-checklist__checkbox" type="checkbox" disabled> <span class="editorjs-checklist__text"><b>BOLD</b></span> </li> <li class="editorjs-checklist__item editorjs-checklist__item--unchecked"> <input class="editorjs-checklist__checkbox" type="checkbox" disabled> <span class="editorjs-checklist__text"><i>ITALIC</i></span> </li> <li class="editorjs-checklist__item editorjs-checklist__item--unchecked"> <input class="editorjs-checklist__checkbox" type="checkbox" disabled> <span class="editorjs-checklist__text">PLAIN TEXT</span> </li> </ul>';
     }
 
     /** @test */

--- a/tests/Feature/Blocks/CodeTest.php
+++ b/tests/Feature/Blocks/CodeTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
+
+use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
+
+class CodeTest extends TestCase
+{
+    protected function getBlockData()
+    {
+        return [
+            "type" => "code",
+            "data" => [
+                "code" => "<?php\n\necho 'Hello World!';\n\n// This is a comment\nfunction test() {\n    return true;\n}"
+            ]
+        ];
+    }
+
+    protected function getBlockHtml()
+    {
+        return '<div class="editor-code"> <code class="code__content">&amp;lt;?phpecho &amp;#039;Hello World!&amp;#039;;// This is a commentfunction test() { return true;}</code></div>';
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_code_block_test(): void
+    {
+        // Arrange
+        $expectedHtml = preg_replace('/\s+/', ' ', $this->getBlockHtml());
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$this->getBlockData()])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_code_block_with_special_characters_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "code",
+            "data" => [
+                "code" => "<script>alert('XSS');</script>\n&amp; special chars"
+            ]
+        ];
+        $expectedHtml = '<div class="editor-code"> <code class="code__content">&amp;lt;script&amp;gt;alert(&amp;#039;XSS&amp;#039;);&amp;lt;/script&amp;gt;&amp;amp;amp; special chars</code></div>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_empty_code_block_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "code",
+            "data" => [
+                "code" => ""
+            ]
+        ];
+        $expectedHtml = '<div class="editor-code"> <code class="code__content"></code></div>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+}

--- a/tests/Feature/Blocks/CodeTest.php
+++ b/tests/Feature/Blocks/CodeTest.php
@@ -18,7 +18,7 @@ class CodeTest extends TestCase
 
     protected function getBlockHtml()
     {
-        return '<div class="editor-code"> <code class="code__content">&amp;lt;?phpecho &amp;#039;Hello World!&amp;#039;;// This is a commentfunction test() { return true;}</code></div>';
+        return '<div class="editorjs-code"> <code class="editorjs-code__content">&amp;lt;?phpecho &amp;#039;Hello World!&amp;#039;;// This is a commentfunction test() { return true;}</code></div>';
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
@@ -44,7 +44,7 @@ class CodeTest extends TestCase
                 "code" => "<script>alert('XSS');</script>\n&amp; special chars"
             ]
         ];
-        $expectedHtml = '<div class="editor-code"> <code class="code__content">&amp;lt;script&amp;gt;alert(&amp;#039;XSS&amp;#039;);&amp;lt;/script&amp;gt;&amp;amp;amp; special chars</code></div>';
+    $expectedHtml = '<div class="editorjs-code"> <code class="editorjs-code__content">&amp;lt;script&amp;gt;alert(&amp;#039;XSS&amp;#039;);&amp;lt;/script&amp;gt;&amp;amp;amp; special chars</code></div>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -64,7 +64,7 @@ class CodeTest extends TestCase
                 "code" => ""
             ]
         ];
-        $expectedHtml = '<div class="editor-code"> <code class="code__content"></code></div>';
+    $expectedHtml = '<div class="editorjs-code"> <code class="editorjs-code__content"></code></div>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act

--- a/tests/Feature/Blocks/DelimiterTest.php
+++ b/tests/Feature/Blocks/DelimiterTest.php
@@ -16,7 +16,7 @@ class DelimiterTest extends TestCase
 
     protected function getBlockHtml()
     {
-        return '<div class="editor-delimiter" style="text-align: center;">***</div>';
+        return '<div class="editorjs-delimiter" style="text-align: center;">***</div>';
     }
 
     #[\PHPUnit\Framework\Attributes\Test]

--- a/tests/Feature/Blocks/DelimiterTest.php
+++ b/tests/Feature/Blocks/DelimiterTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
+
+use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
+
+class DelimiterTest extends TestCase
+{
+    protected function getBlockData()
+    {
+        return [
+            "type" => "delimiter",
+            "data" => []
+        ];
+    }
+
+    protected function getBlockHtml()
+    {
+        return '<div class="editor-delimiter" style="text-align: center;">***</div>';
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_delimiter_block_test(): void
+    {
+        // Arrange
+        $expectedHtml = preg_replace('/\s+/', ' ', $this->getBlockHtml());
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$this->getBlockData()])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_multiple_delimiter_blocks_test(): void
+    {
+        // Arrange
+        $blocks = [
+            $this->getBlockData(),
+            $this->getBlockData(),
+            $this->getBlockData()
+        ];
+        $expectedHtml = str_repeat($this->getBlockHtml(), 3);
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData($blocks)));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+}

--- a/tests/Feature/Blocks/EmbedBlockTest.php
+++ b/tests/Feature/Blocks/EmbedBlockTest.php
@@ -58,7 +58,7 @@ class EmbedBlockTest extends TestCase
         return '<div class="editorjs-embed"><div class="editorjs-embed__content editorjs-embed__content--twitter"><div class="editorjs-embed__twitter"><blockquote class="twitter-tweet"><a href="https://twitter.com/jack/status/20"></a></blockquote><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script></div></div><div class="editorjs-embed__caption">Test Twitter Caption</div></div>';
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function render_youtube_embed_block_test(): void
     {
         $this->assertHtml(
@@ -67,7 +67,7 @@ class EmbedBlockTest extends TestCase
         );
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function render_twitter_embed_block_test(): void
     {
         $this->assertHtml(
@@ -76,7 +76,7 @@ class EmbedBlockTest extends TestCase
         );
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function render_embed_block_with_custom_dimensions_test(): void
     {
         $blockData = $this->getYoutubeBlockData();

--- a/tests/Feature/Blocks/HeaderTest.php
+++ b/tests/Feature/Blocks/HeaderTest.php
@@ -19,7 +19,7 @@ class HeaderTest extends TestCase
 
     protected function getBlockHtml()
     {
-        return '<h2>This is a Header</h2>';
+        return '<h2 class="editorjs-header editorjs-header--level-2">This is a Header</h2>';
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
@@ -46,7 +46,7 @@ class HeaderTest extends TestCase
                 "level" => 1
             ]
         ];
-        $expectedHtml = '<h1>Main Title</h1>';
+    $expectedHtml = '<h1 class="editorjs-header editorjs-header--level-1">Main Title</h1>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -67,7 +67,7 @@ class HeaderTest extends TestCase
                 "level" => 3
             ]
         ];
-        $expectedHtml = '<h3>Subtitle</h3>';
+    $expectedHtml = '<h3 class="editorjs-header editorjs-header--level-3">Subtitle</h3>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -88,7 +88,7 @@ class HeaderTest extends TestCase
                 "level" => 1
             ]
         ];
-        $expectedHtml = '<h1>Default Header</h1>';
+    $expectedHtml = '<h1 class="editorjs-header editorjs-header--level-1">Default Header</h1>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -109,7 +109,7 @@ class HeaderTest extends TestCase
                 "level" => 2
             ]
         ];
-        $expectedHtml = '<h2></h2>';
+    $expectedHtml = '<h2 class="editorjs-header editorjs-header--level-2"></h2>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act

--- a/tests/Feature/Blocks/HeaderTest.php
+++ b/tests/Feature/Blocks/HeaderTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
+
+use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
+
+class HeaderTest extends TestCase
+{
+    protected function getBlockData()
+    {
+        return [
+            "type" => "header",
+            "data" => [
+                "text" => "This is a Header",
+                "level" => 2
+            ]
+        ];
+    }
+
+    protected function getBlockHtml()
+    {
+        return '<h2>This is a Header</h2>';
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_header_block_test(): void
+    {
+        // Arrange
+        $expectedHtml = preg_replace('/\s+/', ' ', $this->getBlockHtml());
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$this->getBlockData()])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_header_h1_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "header",
+            "data" => [
+                "text" => "Main Title",
+                "level" => 1
+            ]
+        ];
+        $expectedHtml = '<h1>Main Title</h1>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_header_h3_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "header",
+            "data" => [
+                "text" => "Subtitle",
+                "level" => 3
+            ]
+        ];
+        $expectedHtml = '<h3>Subtitle</h3>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_header_default_level_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "header",
+            "data" => [
+                "text" => "Default Header",
+                "level" => 1
+            ]
+        ];
+        $expectedHtml = '<h1>Default Header</h1>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_header_empty_text_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "header",
+            "data" => [
+                "text" => "",
+                "level" => 2
+            ]
+        ];
+        $expectedHtml = '<h2></h2>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+}

--- a/tests/Feature/Blocks/ImageTest.php
+++ b/tests/Feature/Blocks/ImageTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
+
+use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
+
+class ImageTest extends TestCase
+{
+    protected function getBlockData()
+    {
+        return [
+            "type" => "image",
+            "data" => [
+                "file" => [
+                    "url" => "https://example.com/image.jpg"
+                ],
+                "caption" => "Sample image caption",
+                "withBorder" => false,
+                "stretched" => false,
+                "withBackground" => false
+            ]
+        ];
+    }
+
+    protected function getBlockHtml()
+    {
+        return '<figure class="image "> <img src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="image-caption"> Sample image caption </footer> </figure>';
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_image_block_test(): void
+    {
+        // Arrange
+        $expectedHtml = preg_replace('/\s+/', ' ', $this->getBlockHtml());
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$this->getBlockData()])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_image_with_border_test(): void
+    {
+        // Arrange
+        $blockData = $this->getBlockData();
+        $blockData['data']['withBorder'] = true;
+        $expectedHtml = '<figure class="image image--bordered"> <img src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="image-caption"> Sample image caption </footer> </figure>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_image_stretched_test(): void
+    {
+        // Arrange
+        $blockData = $this->getBlockData();
+        $blockData['data']['stretched'] = true;
+        $expectedHtml = '<figure class="image image--stretched"> <img src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="image-caption"> Sample image caption </footer> </figure>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_image_with_background_test(): void
+    {
+        // Arrange
+        $blockData = $this->getBlockData();
+        $blockData['data']['withBackground'] = true;
+        $expectedHtml = '<figure class="image image--backgrounded"> <img src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="image-caption"> Sample image caption </footer> </figure>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_image_all_options_test(): void
+    {
+        // Arrange
+        $blockData = $this->getBlockData();
+        $blockData['data']['withBorder'] = true;
+        $blockData['data']['stretched'] = true;
+        $blockData['data']['withBackground'] = true;
+        $expectedHtml = '<figure class="image image--stretched image--bordered image--backgrounded"> <img src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="image-caption"> Sample image caption </footer> </figure>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_image_without_caption_test(): void
+    {
+        // Arrange
+        $blockData = $this->getBlockData();
+        $blockData['data']['caption'] = "";
+        $expectedHtml = '<figure class="image "> <img src="https://example.com/image.jpg" alt=""> </figure>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_image_empty_caption_test(): void
+    {
+        // Arrange
+        $blockData = $this->getBlockData();
+        $blockData['data']['caption'] = '';
+        $expectedHtml = '<figure class="image "> <img src="https://example.com/image.jpg" alt=""> </figure>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+}

--- a/tests/Feature/Blocks/ImageTest.php
+++ b/tests/Feature/Blocks/ImageTest.php
@@ -24,7 +24,7 @@ class ImageTest extends TestCase
 
     protected function getBlockHtml()
     {
-        return '<figure class="image "> <img src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="image-caption"> Sample image caption </footer> </figure>';
+        return '<figure class="editorjs-image "> <img class="editorjs-image__media" src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="editorjs-image__caption"> Sample image caption </footer> </figure>';
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
@@ -46,7 +46,7 @@ class ImageTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['withBorder'] = true;
-        $expectedHtml = '<figure class="image image--bordered"> <img src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="image-caption"> Sample image caption </footer> </figure>';
+    $expectedHtml = '<figure class="editorjs-image editorjs-image--bordered"> <img class="editorjs-image__media" src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="editorjs-image__caption"> Sample image caption </footer> </figure>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -62,7 +62,7 @@ class ImageTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['stretched'] = true;
-        $expectedHtml = '<figure class="image image--stretched"> <img src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="image-caption"> Sample image caption </footer> </figure>';
+    $expectedHtml = '<figure class="editorjs-image editorjs-image--stretched"> <img class="editorjs-image__media" src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="editorjs-image__caption"> Sample image caption </footer> </figure>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -78,7 +78,7 @@ class ImageTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['withBackground'] = true;
-        $expectedHtml = '<figure class="image image--backgrounded"> <img src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="image-caption"> Sample image caption </footer> </figure>';
+    $expectedHtml = '<figure class="editorjs-image editorjs-image--backgrounded"> <img class="editorjs-image__media" src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="editorjs-image__caption"> Sample image caption </footer> </figure>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -96,7 +96,7 @@ class ImageTest extends TestCase
         $blockData['data']['withBorder'] = true;
         $blockData['data']['stretched'] = true;
         $blockData['data']['withBackground'] = true;
-        $expectedHtml = '<figure class="image image--stretched image--bordered image--backgrounded"> <img src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="image-caption"> Sample image caption </footer> </figure>';
+    $expectedHtml = '<figure class="editorjs-image editorjs-image--stretched editorjs-image--bordered editorjs-image--backgrounded"> <img class="editorjs-image__media" src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="editorjs-image__caption"> Sample image caption </footer> </figure>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -112,7 +112,7 @@ class ImageTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['caption'] = "";
-        $expectedHtml = '<figure class="image "> <img src="https://example.com/image.jpg" alt=""> </figure>';
+    $expectedHtml = '<figure class="editorjs-image "> <img class="editorjs-image__media" src="https://example.com/image.jpg" alt=""> </figure>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -128,7 +128,7 @@ class ImageTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['caption'] = '';
-        $expectedHtml = '<figure class="image "> <img src="https://example.com/image.jpg" alt=""> </figure>';
+    $expectedHtml = '<figure class="editorjs-image "> <img class="editorjs-image__media" src="https://example.com/image.jpg" alt=""> </figure>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act

--- a/tests/Feature/Blocks/LinkTest.php
+++ b/tests/Feature/Blocks/LinkTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
+
+use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
+
+class LinkTest extends TestCase
+{
+    protected function getBlockData()
+    {
+        return [
+            "type" => "linkTool",
+            "data" => [
+                "link" => "https://example.com",
+                "meta" => [
+                    "title" => "Example Website",
+                    "description" => "This is an example website for testing purposes",
+                    "image" => [
+                        "url" => "https://example.com/image.jpg"
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    protected function getBlockHtml()
+    {
+        return '<a class="embed-link" href="https://example.com" target="_blank" rel="nofollow"> <img class="embed-link__image" src="https://example.com/image.jpg"> <div class="embed-link__title"> Example Website </div> <div class="embed-link__description"> This is an example website for testing purposes </div> <span class="embed-link__domain"> example.com </span></a>';
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_link_block_test(): void
+    {
+        // Arrange
+        $expectedHtml = preg_replace('/\s+/', ' ', $this->getBlockHtml());
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$this->getBlockData()])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_link_without_image_test(): void
+    {
+        // Arrange
+        $blockData = $this->getBlockData();
+        unset($blockData['data']['meta']['image']);
+        $expectedHtml = '<a class="embed-link" href="https://example.com" target="_blank" rel="nofollow"> <div class="embed-link__title"> Example Website </div> <div class="embed-link__description"> This is an example website for testing purposes </div> <span class="embed-link__domain"> example.com </span></a>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_link_with_empty_image_url_test(): void
+    {
+        // Arrange
+        $blockData = $this->getBlockData();
+        $blockData['data']['meta']['image']['url'] = '';
+        $expectedHtml = '<a class="embed-link" href="https://example.com" target="_blank" rel="nofollow"> <div class="embed-link__title"> Example Website </div> <div class="embed-link__description"> This is an example website for testing purposes </div> <span class="embed-link__domain"> example.com </span></a>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_link_with_subdomain_test(): void
+    {
+        // Arrange
+        $blockData = $this->getBlockData();
+        $blockData['data']['link'] = 'https://blog.example.com/article';
+        $expectedHtml = '<a class="embed-link" href="https://blog.example.com/article" target="_blank" rel="nofollow"> <img class="embed-link__image" src="https://example.com/image.jpg"> <div class="embed-link__title"> Example Website </div> <div class="embed-link__description"> This is an example website for testing purposes </div> <span class="embed-link__domain"> blog.example.com </span></a>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_link_minimal_data_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "linkTool",
+            "data" => [
+                "link" => "https://minimal.com",
+                "meta" => [
+                    "title" => "Minimal Link",
+                    "description" => "Basic description"
+                ]
+            ]
+        ];
+        $expectedHtml = '<a class="embed-link" href="https://minimal.com" target="_blank" rel="nofollow"> <div class="embed-link__title"> Minimal Link </div> <div class="embed-link__description"> Basic description </div> <span class="embed-link__domain"> minimal.com </span></a>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+}

--- a/tests/Feature/Blocks/LinkTest.php
+++ b/tests/Feature/Blocks/LinkTest.php
@@ -25,7 +25,7 @@ class LinkTest extends TestCase
 
     protected function getBlockHtml()
     {
-        return '<a class="embed-link" href="https://example.com" target="_blank" rel="nofollow"> <img class="embed-link__image" src="https://example.com/image.jpg"> <div class="embed-link__title"> Example Website </div> <div class="embed-link__description"> This is an example website for testing purposes </div> <span class="embed-link__domain"> example.com </span></a>';
+        return '<a class="editorjs-link" href="https://example.com" target="_blank" rel="nofollow"> <img class="editorjs-link__image" src="https://example.com/image.jpg"> <div class="editorjs-link__title"> Example Website </div> <div class="editorjs-link__description"> This is an example website for testing purposes </div> <span class="editorjs-link__domain"> example.com </span></a>';
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
@@ -47,7 +47,7 @@ class LinkTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         unset($blockData['data']['meta']['image']);
-        $expectedHtml = '<a class="embed-link" href="https://example.com" target="_blank" rel="nofollow"> <div class="embed-link__title"> Example Website </div> <div class="embed-link__description"> This is an example website for testing purposes </div> <span class="embed-link__domain"> example.com </span></a>';
+    $expectedHtml = '<a class="editorjs-link" href="https://example.com" target="_blank" rel="nofollow"> <div class="editorjs-link__title"> Example Website </div> <div class="editorjs-link__description"> This is an example website for testing purposes </div> <span class="editorjs-link__domain"> example.com </span></a>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -63,7 +63,7 @@ class LinkTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['meta']['image']['url'] = '';
-        $expectedHtml = '<a class="embed-link" href="https://example.com" target="_blank" rel="nofollow"> <div class="embed-link__title"> Example Website </div> <div class="embed-link__description"> This is an example website for testing purposes </div> <span class="embed-link__domain"> example.com </span></a>';
+    $expectedHtml = '<a class="editorjs-link" href="https://example.com" target="_blank" rel="nofollow"> <div class="editorjs-link__title"> Example Website </div> <div class="editorjs-link__description"> This is an example website for testing purposes </div> <span class="editorjs-link__domain"> example.com </span></a>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -79,7 +79,7 @@ class LinkTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['link'] = 'https://blog.example.com/article';
-        $expectedHtml = '<a class="embed-link" href="https://blog.example.com/article" target="_blank" rel="nofollow"> <img class="embed-link__image" src="https://example.com/image.jpg"> <div class="embed-link__title"> Example Website </div> <div class="embed-link__description"> This is an example website for testing purposes </div> <span class="embed-link__domain"> blog.example.com </span></a>';
+    $expectedHtml = '<a class="editorjs-link" href="https://blog.example.com/article" target="_blank" rel="nofollow"> <img class="editorjs-link__image" src="https://example.com/image.jpg"> <div class="editorjs-link__title"> Example Website </div> <div class="editorjs-link__description"> This is an example website for testing purposes </div> <span class="editorjs-link__domain"> blog.example.com </span></a>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -103,7 +103,7 @@ class LinkTest extends TestCase
                 ]
             ]
         ];
-        $expectedHtml = '<a class="embed-link" href="https://minimal.com" target="_blank" rel="nofollow"> <div class="embed-link__title"> Minimal Link </div> <div class="embed-link__description"> Basic description </div> <span class="embed-link__domain"> minimal.com </span></a>';
+    $expectedHtml = '<a class="editorjs-link" href="https://minimal.com" target="_blank" rel="nofollow"> <div class="editorjs-link__title"> Minimal Link </div> <div class="editorjs-link__description"> Basic description </div> <span class="editorjs-link__domain"> minimal.com </span></a>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act

--- a/tests/Feature/Blocks/ListBlockTest.php
+++ b/tests/Feature/Blocks/ListBlockTest.php
@@ -22,7 +22,7 @@ class ListBlockTest extends TestCase
 
     protected function getBlockHtml()
     {
-        return "<ul>        <li>Hello</li>        <li>World</li>    </ul>";
+        return "<ul class=\"editorjs-list editorjs-list--unordered\">        <li class=\"editorjs-list__item editorjs-list__item--odd\">Hello</li>        <li class=\"editorjs-list__item editorjs-list__item--even\">World</li>    </ul>";
     }
 
     /** @test */

--- a/tests/Feature/Blocks/ListBlockTest.php
+++ b/tests/Feature/Blocks/ListBlockTest.php
@@ -25,7 +25,7 @@ class ListBlockTest extends TestCase
         return "<ul>        <li>Hello</li>        <li>World</li>    </ul>";
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function render_paragraph_block_test(): void
     {
         $this->assertEquals(

--- a/tests/Feature/Blocks/ListTest.php
+++ b/tests/Feature/Blocks/ListTest.php
@@ -23,7 +23,7 @@ class ListTest extends TestCase
 
     protected function getBlockHtml()
     {
-        return '<ul> <li>First item</li> <li>Second item</li> <li>Third item</li> </ul>';
+        return '<ul class="editorjs-list editorjs-list--unordered"> <li class="editorjs-list__item editorjs-list__item--odd">First item</li> <li class="editorjs-list__item editorjs-list__item--even">Second item</li> <li class="editorjs-list__item editorjs-list__item--odd">Third item</li> </ul>';
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
@@ -45,7 +45,7 @@ class ListTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['style'] = 'ordered';
-        $expectedHtml = '<ol> <li>First item</li> <li>Second item</li> <li>Third item</li> </ol>';
+    $expectedHtml = '<ol class="editorjs-list editorjs-list--ordered"> <li class="editorjs-list__item editorjs-list__item--odd">First item</li> <li class="editorjs-list__item editorjs-list__item--even">Second item</li> <li class="editorjs-list__item editorjs-list__item--odd">Third item</li> </ol>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -69,7 +69,7 @@ class ListTest extends TestCase
                 ]
             ]
         ];
-        $expectedHtml = '<ol> <li>First item</li> <li>Second item</li> </ol>';
+    $expectedHtml = '<ol class="editorjs-list editorjs-list--ordered"> <li class="editorjs-list__item editorjs-list__item--odd">First item</li> <li class="editorjs-list__item editorjs-list__item--even">Second item</li> </ol>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -92,7 +92,7 @@ class ListTest extends TestCase
                 ]
             ]
         ];
-        $expectedHtml = '<ul> <li>Only item</li> </ul>';
+    $expectedHtml = '<ul class="editorjs-list editorjs-list--unordered"> <li class="editorjs-list__item editorjs-list__item--odd">Only item</li> </ul>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -113,7 +113,7 @@ class ListTest extends TestCase
                 "items" => []
             ]
         ];
-        $expectedHtml = '<ul> </ul>';
+    $expectedHtml = '<ul class="editorjs-list editorjs-list--unordered"> </ul>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -138,7 +138,7 @@ class ListTest extends TestCase
                 ]
             ]
         ];
-        $expectedHtml = '<ul> <li>&lt;b&gt;Bold item&lt;/b&gt;</li> <li>&lt;i&gt;Italic item&lt;/i&gt;</li> <li>&lt;a href=&quot;https://example.com&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;Link item&lt;/a&gt;</li> </ul>';
+    $expectedHtml = '<ul class="editorjs-list editorjs-list--unordered"> <li class="editorjs-list__item editorjs-list__item--odd">&lt;b&gt;Bold item&lt;/b&gt;</li> <li class="editorjs-list__item editorjs-list__item--even">&lt;i&gt;Italic item&lt;/i&gt;</li> <li class="editorjs-list__item editorjs-list__item--odd">&lt;a href=&quot;https://example.com&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;Link item&lt;/a&gt;</li> </ul>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act

--- a/tests/Feature/Blocks/ListTest.php
+++ b/tests/Feature/Blocks/ListTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
+
+use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
+
+class ListTest extends TestCase
+{
+    protected function getBlockData()
+    {
+        return [
+            "type" => "list",
+            "data" => [
+                "style" => "unordered",
+                "items" => [
+                    "First item",
+                    "Second item",
+                    "Third item"
+                ]
+            ]
+        ];
+    }
+
+    protected function getBlockHtml()
+    {
+        return '<ul> <li>First item</li> <li>Second item</li> <li>Third item</li> </ul>';
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_unordered_list_block_test(): void
+    {
+        // Arrange
+        $expectedHtml = preg_replace('/\s+/', ' ', $this->getBlockHtml());
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$this->getBlockData()])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_ordered_list_block_test(): void
+    {
+        // Arrange
+        $blockData = $this->getBlockData();
+        $blockData['data']['style'] = 'ordered';
+        $expectedHtml = '<ol> <li>First item</li> <li>Second item</li> <li>Third item</li> </ol>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_list_with_type_property_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "list",
+            "data" => [
+                "style" => "ordered",
+                "items" => [
+                    "First item",
+                    "Second item"
+                ]
+            ]
+        ];
+        $expectedHtml = '<ol> <li>First item</li> <li>Second item</li> </ol>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_list_default_style_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "list",
+            "data" => [
+                "style" => "unordered",
+                "items" => [
+                    "Only item"
+                ]
+            ]
+        ];
+        $expectedHtml = '<ul> <li>Only item</li> </ul>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_empty_list_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "list",
+            "data" => [
+                "style" => "unordered",
+                "items" => []
+            ]
+        ];
+        $expectedHtml = '<ul> </ul>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_list_with_html_content_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "list",
+            "data" => [
+                "style" => "unordered",
+                "items" => [
+                    "<b>Bold item</b>",
+                    "<i>Italic item</i>",
+                    "<a href=\"https://example.com\">Link item</a>"
+                ]
+            ]
+        ];
+        $expectedHtml = '<ul> <li>&lt;b&gt;Bold item&lt;/b&gt;</li> <li>&lt;i&gt;Italic item&lt;/i&gt;</li> <li>&lt;a href=&quot;https://example.com&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;Link item&lt;/a&gt;</li> </ul>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+}

--- a/tests/Feature/Blocks/ParagraphBlockTest.php
+++ b/tests/Feature/Blocks/ParagraphBlockTest.php
@@ -18,7 +18,7 @@ class ParagraphBlockTest extends TestCase
 
     protected function getBlockHtml()
     {
-        return "<p>Hello world!</p>";
+        return "<p class=\"editorjs-paragraph\">Hello world!</p>";
     }
 
     /** @test */

--- a/tests/Feature/Blocks/ParagraphBlockTest.php
+++ b/tests/Feature/Blocks/ParagraphBlockTest.php
@@ -21,7 +21,7 @@ class ParagraphBlockTest extends TestCase
         return "<p>Hello world!</p>";
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function render_paragraph_block_test(): void
     {
         $this->assertEquals(

--- a/tests/Feature/Blocks/ParagraphTest.php
+++ b/tests/Feature/Blocks/ParagraphTest.php
@@ -18,7 +18,7 @@ class ParagraphTest extends TestCase
 
     protected function getBlockHtml()
     {
-        return '<p>This is a simple paragraph with some text content.</p>';
+        return '<p class="editorjs-paragraph">This is a simple paragraph with some text content.</p>';
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
@@ -44,7 +44,7 @@ class ParagraphTest extends TestCase
                 "text" => "This paragraph contains <b>bold</b>, <i>italic</i>, and <a href=\"https://example.com\">link</a> elements."
             ]
         ];
-        $expectedHtml = '<p>This paragraph contains &lt;b&gt;bold&lt;/b&gt;, &lt;i&gt;italic&lt;/i&gt;, and &lt;a href=&quot;https://example.com&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;link&lt;/a&gt; elements.</p>';
+    $expectedHtml = '<p class="editorjs-paragraph">This paragraph contains &lt;b&gt;bold&lt;/b&gt;, &lt;i&gt;italic&lt;/i&gt;, and &lt;a href=&quot;https://example.com&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;link&lt;/a&gt; elements.</p>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -64,7 +64,7 @@ class ParagraphTest extends TestCase
                 "text" => ""
             ]
         ];
-        $expectedHtml = '<p></p>';
+    $expectedHtml = '<p class="editorjs-paragraph"></p>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -84,7 +84,7 @@ class ParagraphTest extends TestCase
                 "text" => "This is line one\nThis is line two\nThis is line three"
             ]
         ];
-        $expectedHtml = '<p>This is line oneThis is line twoThis is line three</p>';
+    $expectedHtml = '<p class="editorjs-paragraph">This is line oneThis is line twoThis is line three</p>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -104,7 +104,7 @@ class ParagraphTest extends TestCase
                 "text" => "Special chars: &amp; &lt; &gt; &quot; &#39;"
             ]
         ];
-        $expectedHtml = '<p>Special chars: &amp;amp; &amp;lt; &amp;gt; &quot; &#039;</p>';
+    $expectedHtml = '<p class="editorjs-paragraph">Special chars: &amp;amp; &amp;lt; &amp;gt; &quot; &#039;</p>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -132,7 +132,7 @@ class ParagraphTest extends TestCase
                 ]
             ]
         ];
-        $expectedHtml = '<p>First paragraph</p><p>Second paragraph</p>';
+    $expectedHtml = '<p class="editorjs-paragraph">First paragraph</p><p class="editorjs-paragraph">Second paragraph</p>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act

--- a/tests/Feature/Blocks/ParagraphTest.php
+++ b/tests/Feature/Blocks/ParagraphTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
+
+use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
+
+class ParagraphTest extends TestCase
+{
+    protected function getBlockData()
+    {
+        return [
+            "type" => "paragraph",
+            "data" => [
+                "text" => "This is a simple paragraph with some text content."
+            ]
+        ];
+    }
+
+    protected function getBlockHtml()
+    {
+        return '<p>This is a simple paragraph with some text content.</p>';
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_paragraph_block_test(): void
+    {
+        // Arrange
+        $expectedHtml = preg_replace('/\s+/', ' ', $this->getBlockHtml());
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$this->getBlockData()])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_paragraph_with_html_content_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "paragraph",
+            "data" => [
+                "text" => "This paragraph contains <b>bold</b>, <i>italic</i>, and <a href=\"https://example.com\">link</a> elements."
+            ]
+        ];
+        $expectedHtml = '<p>This paragraph contains &lt;b&gt;bold&lt;/b&gt;, &lt;i&gt;italic&lt;/i&gt;, and &lt;a href=&quot;https://example.com&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;link&lt;/a&gt; elements.</p>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_empty_paragraph_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "paragraph",
+            "data" => [
+                "text" => ""
+            ]
+        ];
+        $expectedHtml = '<p></p>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_paragraph_with_line_breaks_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "paragraph",
+            "data" => [
+                "text" => "This is line one\nThis is line two\nThis is line three"
+            ]
+        ];
+        $expectedHtml = '<p>This is line oneThis is line twoThis is line three</p>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_paragraph_with_special_characters_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "paragraph",
+            "data" => [
+                "text" => "Special chars: &amp; &lt; &gt; &quot; &#39;"
+            ]
+        ];
+        $expectedHtml = '<p>Special chars: &amp;amp; &amp;lt; &amp;gt; &quot; &#039;</p>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_multiple_paragraphs_test(): void
+    {
+        // Arrange
+        $blocks = [
+            [
+                "type" => "paragraph",
+                "data" => [
+                    "text" => "First paragraph"
+                ]
+            ],
+            [
+                "type" => "paragraph",
+                "data" => [
+                    "text" => "Second paragraph"
+                ]
+            ]
+        ];
+        $expectedHtml = '<p>First paragraph</p><p>Second paragraph</p>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData($blocks)));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+}

--- a/tests/Feature/Blocks/QuoteTest.php
+++ b/tests/Feature/Blocks/QuoteTest.php
@@ -20,7 +20,7 @@ class QuoteTest extends TestCase
 
     protected function getBlockHtml()
     {
-        return '<blockquote class="editor-quote"> <p class="text-left">This is a quote text that demonstrates the quote block functionality.</p> <small class="text-left">— Quote Author</small> </blockquote>';
+        return '<blockquote class="editorjs-quote"> <p class="editorjs-quote__text text-left">This is a quote text that demonstrates the quote block functionality.</p> <small class="editorjs-quote__caption text-left">— Quote Author</small> </blockquote>';
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
@@ -42,7 +42,7 @@ class QuoteTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['alignment'] = 'center';
-        $expectedHtml = '<blockquote class="editor-quote"> <p class="text-center">This is a quote text that demonstrates the quote block functionality.</p> <small class="text-center">— Quote Author</small> </blockquote>';
+    $expectedHtml = '<blockquote class="editorjs-quote"> <p class="editorjs-quote__text text-center">This is a quote text that demonstrates the quote block functionality.</p> <small class="editorjs-quote__caption text-center">— Quote Author</small> </blockquote>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -58,7 +58,7 @@ class QuoteTest extends TestCase
         // Arrange  
         $blockData = $this->getBlockData();
         $blockData['data']['alignment'] = 'left'; // Test left alignment as default is not supported
-        $expectedHtml = '<blockquote class="editor-quote"> <p class="text-left">This is a quote text that demonstrates the quote block functionality.</p> <small class="text-left">— Quote Author</small> </blockquote>';
+    $expectedHtml = '<blockquote class="editorjs-quote"> <p class="editorjs-quote__text text-left">This is a quote text that demonstrates the quote block functionality.</p> <small class="editorjs-quote__caption text-left">— Quote Author</small> </blockquote>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -74,7 +74,7 @@ class QuoteTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['caption'] = "";
-        $expectedHtml = '<blockquote class="editor-quote"> <p class="text-left">This is a quote text that demonstrates the quote block functionality.</p> </blockquote>';
+    $expectedHtml = '<blockquote class="editorjs-quote"> <p class="editorjs-quote__text text-left">This is a quote text that demonstrates the quote block functionality.</p> </blockquote>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -90,7 +90,7 @@ class QuoteTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['caption'] = '';
-        $expectedHtml = '<blockquote class="editor-quote"> <p class="text-left">This is a quote text that demonstrates the quote block functionality.</p> </blockquote>';
+    $expectedHtml = '<blockquote class="editorjs-quote"> <p class="editorjs-quote__text text-left">This is a quote text that demonstrates the quote block functionality.</p> </blockquote>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act

--- a/tests/Feature/Blocks/QuoteTest.php
+++ b/tests/Feature/Blocks/QuoteTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
+
+use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
+
+class QuoteTest extends TestCase
+{
+    protected function getBlockData()
+    {
+        return [
+            "type" => "quote",
+            "data" => [
+                "text" => "This is a quote text that demonstrates the quote block functionality.",
+                "caption" => "Quote Author",
+                "alignment" => "left"
+            ]
+        ];
+    }
+
+    protected function getBlockHtml()
+    {
+        return '<blockquote class="editor-quote"> <p class="text-left">This is a quote text that demonstrates the quote block functionality.</p> <small class="text-left">— Quote Author</small> </blockquote>';
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_quote_block_test(): void
+    {
+        // Arrange
+        $expectedHtml = preg_replace('/\s+/', ' ', $this->getBlockHtml());
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$this->getBlockData()])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_quote_center_alignment_test(): void
+    {
+        // Arrange
+        $blockData = $this->getBlockData();
+        $blockData['data']['alignment'] = 'center';
+        $expectedHtml = '<blockquote class="editor-quote"> <p class="text-center">This is a quote text that demonstrates the quote block functionality.</p> <small class="text-center">— Quote Author</small> </blockquote>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_quote_default_alignment_test(): void
+    {
+        // Arrange  
+        $blockData = $this->getBlockData();
+        $blockData['data']['alignment'] = 'left'; // Test left alignment as default is not supported
+        $expectedHtml = '<blockquote class="editor-quote"> <p class="text-left">This is a quote text that demonstrates the quote block functionality.</p> <small class="text-left">— Quote Author</small> </blockquote>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_quote_without_caption_test(): void
+    {
+        // Arrange
+        $blockData = $this->getBlockData();
+        $blockData['data']['caption'] = "";
+        $expectedHtml = '<blockquote class="editor-quote"> <p class="text-left">This is a quote text that demonstrates the quote block functionality.</p> </blockquote>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_quote_empty_caption_test(): void
+    {
+        // Arrange
+        $blockData = $this->getBlockData();
+        $blockData['data']['caption'] = '';
+        $expectedHtml = '<blockquote class="editor-quote"> <p class="text-left">This is a quote text that demonstrates the quote block functionality.</p> </blockquote>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+
+}

--- a/tests/Feature/Blocks/RawTest.php
+++ b/tests/Feature/Blocks/RawTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
+
+use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
+
+class RawTest extends TestCase
+{
+    protected function getBlockData()
+    {
+        return [
+            "type" => "raw",
+            "data" => [
+                "html" => "<div class=\"custom-widget\">\n    <h3>Custom HTML Content</h3>\n    <p>This is raw HTML content.</p>\n</div>"
+            ]
+        ];
+    }
+
+    protected function getBlockHtml()
+    {
+        return '<div style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> &lt;div class=&quot;custom-widget&quot;&gt; &lt;h3&gt;Custom HTML Content&lt;/h3&gt; &lt;p&gt;This is raw HTML content.&lt;/p&gt;&lt;/div&gt;</div>';
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_raw_block_test(): void
+    {
+        // Arrange
+        $expectedHtml = preg_replace('/\s+/', ' ', $this->getBlockHtml());
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$this->getBlockData()])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_raw_block_with_script_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "raw",
+            "data" => [
+                "html" => "<script>console.log('Hello World!');</script>"
+            ]
+        ];
+        $expectedHtml = '<div style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> &lt;script&gt;console.log(&#039;Hello World!&#039;);&lt;/script&gt;</div>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_raw_block_with_complex_html_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "raw",
+            "data" => [
+                "html" => "<iframe src=\"https://example.com\" width=\"100%\" height=\"400\"></iframe>"
+            ]
+        ];
+        $expectedHtml = '<div style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> &lt;iframe src=&quot;https://example.com&quot; width=&quot;100%&quot; height=&quot;400&quot;&gt;&lt;/iframe&gt;</div>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_empty_raw_block_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "raw",
+            "data" => [
+                "html" => ""
+            ]
+        ];
+        $expectedHtml = '<div style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> </div>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_raw_block_with_text_content_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "raw",
+            "data" => [
+                "html" => "Plain text content without HTML tags"
+            ]
+        ];
+        $expectedHtml = '<div style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> Plain text content without HTML tags</div>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+}

--- a/tests/Feature/Blocks/RawTest.php
+++ b/tests/Feature/Blocks/RawTest.php
@@ -18,7 +18,7 @@ class RawTest extends TestCase
 
     protected function getBlockHtml()
     {
-        return '<div style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> &lt;div class=&quot;custom-widget&quot;&gt; &lt;h3&gt;Custom HTML Content&lt;/h3&gt; &lt;p&gt;This is raw HTML content.&lt;/p&gt;&lt;/div&gt;</div>';
+        return '<div class="editorjs-raw" style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> &lt;div class=&quot;custom-widget&quot;&gt; &lt;h3&gt;Custom HTML Content&lt;/h3&gt; &lt;p&gt;This is raw HTML content.&lt;/p&gt;&lt;/div&gt;</div>';
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
@@ -44,7 +44,7 @@ class RawTest extends TestCase
                 "html" => "<script>console.log('Hello World!');</script>"
             ]
         ];
-        $expectedHtml = '<div style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> &lt;script&gt;console.log(&#039;Hello World!&#039;);&lt;/script&gt;</div>';
+    $expectedHtml = '<div class="editorjs-raw" style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> &lt;script&gt;console.log(&#039;Hello World!&#039;);&lt;/script&gt;</div>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -64,7 +64,7 @@ class RawTest extends TestCase
                 "html" => "<iframe src=\"https://example.com\" width=\"100%\" height=\"400\"></iframe>"
             ]
         ];
-        $expectedHtml = '<div style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> &lt;iframe src=&quot;https://example.com&quot; width=&quot;100%&quot; height=&quot;400&quot;&gt;&lt;/iframe&gt;</div>';
+    $expectedHtml = '<div class="editorjs-raw" style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> &lt;iframe src=&quot;https://example.com&quot; width=&quot;100%&quot; height=&quot;400&quot;&gt;&lt;/iframe&gt;</div>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -84,7 +84,7 @@ class RawTest extends TestCase
                 "html" => ""
             ]
         ];
-        $expectedHtml = '<div style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> </div>';
+    $expectedHtml = '<div class="editorjs-raw" style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> </div>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -104,7 +104,7 @@ class RawTest extends TestCase
                 "html" => "Plain text content without HTML tags"
             ]
         ];
-        $expectedHtml = '<div style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> Plain text content without HTML tags</div>';
+    $expectedHtml = '<div class="editorjs-raw" style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> Plain text content without HTML tags</div>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act

--- a/tests/Feature/Blocks/TableTest.php
+++ b/tests/Feature/Blocks/TableTest.php
@@ -23,7 +23,7 @@ class TableTest extends TestCase
 
     protected function getBlockHtml()
     {
-        return '<table class="table"> <tr> <th> Name </th> <th> Age </th> <th> City </th> </tr> <tr> <td> John Doe </td> <td> 30 </td> <td> New York </td> </tr> <tr> <td> Jane Smith </td> <td> 25 </td> <td> Los Angeles </td> </tr> </table>';
+        return '<table class="editorjs-table"> <tr class="editorjs-table__row"> <th class="editorjs-table__cell"> Name </th> <th class="editorjs-table__cell"> Age </th> <th class="editorjs-table__cell"> City </th> </tr> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> John Doe </td> <td class="editorjs-table__cell"> 30 </td> <td class="editorjs-table__cell"> New York </td> </tr> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> Jane Smith </td> <td class="editorjs-table__cell"> 25 </td> <td class="editorjs-table__cell"> Los Angeles </td> </tr> </table>';
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
@@ -45,7 +45,7 @@ class TableTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['withHeadings'] = false;
-        $expectedHtml = '<table class="table"> <tr> <td> Name </td> <td> Age </td> <td> City </td> </tr> <tr> <td> John Doe </td> <td> 30 </td> <td> New York </td> </tr> <tr> <td> Jane Smith </td> <td> 25 </td> <td> Los Angeles </td> </tr> </table>';
+    $expectedHtml = '<table class="editorjs-table"> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> Name </td> <td class="editorjs-table__cell"> Age </td> <td class="editorjs-table__cell"> City </td> </tr> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> John Doe </td> <td class="editorjs-table__cell"> 30 </td> <td class="editorjs-table__cell"> New York </td> </tr> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> Jane Smith </td> <td class="editorjs-table__cell"> 25 </td> <td class="editorjs-table__cell"> Los Angeles </td> </tr> </table>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -68,7 +68,7 @@ class TableTest extends TestCase
                 ]
             ]
         ];
-        $expectedHtml = '<table class="table"> <tr> <th> Header 1 </th> <th> Header 2 </th> </tr> </table>';
+    $expectedHtml = '<table class="editorjs-table"> <tr class="editorjs-table__row"> <th class="editorjs-table__cell"> Header 1 </th> <th class="editorjs-table__cell"> Header 2 </th> </tr> </table>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -93,7 +93,7 @@ class TableTest extends TestCase
                 ]
             ]
         ];
-        $expectedHtml = '<table class="table"> <tr> <td> A </td> <td> </td> <td> C </td> </tr> <tr> <td> </td> <td> E </td> <td> </td> </tr> <tr> <td> G </td> <td> H </td> <td> I </td> </tr> </table>';
+    $expectedHtml = '<table class="editorjs-table"> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> A </td> <td class="editorjs-table__cell"> </td> <td class="editorjs-table__cell"> C </td> </tr> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> </td> <td class="editorjs-table__cell"> E </td> <td class="editorjs-table__cell"> </td> </tr> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> G </td> <td class="editorjs-table__cell"> H </td> <td class="editorjs-table__cell"> I </td> </tr> </table>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -117,7 +117,7 @@ class TableTest extends TestCase
                 ]
             ]
         ];
-        $expectedHtml = '<table class="table"> <tr> <th> &lt;b&gt;Bold Header&lt;/b&gt; </th> <th> Normal Header </th> </tr> <tr> <td> &lt;a href=&quot;#&quot;&gt;Link&lt;/a&gt; </td> <td> &lt;i&gt;Italic text&lt;/i&gt; </td> </tr> </table>';
+    $expectedHtml = '<table class="editorjs-table"> <tr class="editorjs-table__row"> <th class="editorjs-table__cell"> &lt;b&gt;Bold Header&lt;/b&gt; </th> <th class="editorjs-table__cell"> Normal Header </th> </tr> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> &lt;a href=&quot;#&quot;&gt;Link&lt;/a&gt; </td> <td class="editorjs-table__cell"> &lt;i&gt;Italic text&lt;/i&gt; </td> </tr> </table>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -138,7 +138,7 @@ class TableTest extends TestCase
                 "content" => []
             ]
         ];
-        $expectedHtml = '<table class="table"> </table>';
+    $expectedHtml = '<table class="editorjs-table"> </table>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act
@@ -162,7 +162,7 @@ class TableTest extends TestCase
                 ]
             ]
         ];
-        $expectedHtml = '<table class="table"> <tr> <td> Col1 </td> <td> Col2 </td> </tr> <tr> <td> Data1 </td> <td> Data2 </td> </tr> </table>';
+    $expectedHtml = '<table class="editorjs-table"> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> Col1 </td> <td class="editorjs-table__cell"> Col2 </td> </tr> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> Data1 </td> <td class="editorjs-table__cell"> Data2 </td> </tr> </table>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
         
         // Act

--- a/tests/Feature/Blocks/TableTest.php
+++ b/tests/Feature/Blocks/TableTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
+
+use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
+
+class TableTest extends TestCase
+{
+    protected function getBlockData()
+    {
+        return [
+            "type" => "table",
+            "data" => [
+                "withHeadings" => true,
+                "content" => [
+                    ["Name", "Age", "City"],
+                    ["John Doe", "30", "New York"],
+                    ["Jane Smith", "25", "Los Angeles"]
+                ]
+            ]
+        ];
+    }
+
+    protected function getBlockHtml()
+    {
+        return '<table class="table"> <tr> <th> Name </th> <th> Age </th> <th> City </th> </tr> <tr> <td> John Doe </td> <td> 30 </td> <td> New York </td> </tr> <tr> <td> Jane Smith </td> <td> 25 </td> <td> Los Angeles </td> </tr> </table>';
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_table_with_headings_test(): void
+    {
+        // Arrange
+        $expectedHtml = preg_replace('/\s+/', ' ', $this->getBlockHtml());
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$this->getBlockData()])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_table_without_headings_test(): void
+    {
+        // Arrange
+        $blockData = $this->getBlockData();
+        $blockData['data']['withHeadings'] = false;
+        $expectedHtml = '<table class="table"> <tr> <td> Name </td> <td> Age </td> <td> City </td> </tr> <tr> <td> John Doe </td> <td> 30 </td> <td> New York </td> </tr> <tr> <td> Jane Smith </td> <td> 25 </td> <td> Los Angeles </td> </tr> </table>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_single_row_table_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "table",
+            "data" => [
+                "withHeadings" => true,
+                "content" => [
+                    ["Header 1", "Header 2"]
+                ]
+            ]
+        ];
+        $expectedHtml = '<table class="table"> <tr> <th> Header 1 </th> <th> Header 2 </th> </tr> </table>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_table_with_empty_cells_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "table",
+            "data" => [
+                "withHeadings" => false,
+                "content" => [
+                    ["A", "", "C"],
+                    ["", "E", ""],
+                    ["G", "H", "I"]
+                ]
+            ]
+        ];
+        $expectedHtml = '<table class="table"> <tr> <td> A </td> <td> </td> <td> C </td> </tr> <tr> <td> </td> <td> E </td> <td> </td> </tr> <tr> <td> G </td> <td> H </td> <td> I </td> </tr> </table>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_table_with_html_content_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "table",
+            "data" => [
+                "withHeadings" => true,
+                "content" => [
+                    ["<b>Bold Header</b>", "Normal Header"],
+                    ["<a href=\"#\">Link</a>", "<i>Italic text</i>"]
+                ]
+            ]
+        ];
+        $expectedHtml = '<table class="table"> <tr> <th> &lt;b&gt;Bold Header&lt;/b&gt; </th> <th> Normal Header </th> </tr> <tr> <td> &lt;a href=&quot;#&quot;&gt;Link&lt;/a&gt; </td> <td> &lt;i&gt;Italic text&lt;/i&gt; </td> </tr> </table>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_empty_table_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "table",
+            "data" => [
+                "withHeadings" => false,
+                "content" => []
+            ]
+        ];
+        $expectedHtml = '<table class="table"> </table>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function render_table_with_default_withHeadings_test(): void
+    {
+        // Arrange
+        $blockData = [
+            "type" => "table",
+            "data" => [
+                "withHeadings" => false,
+                "content" => [
+                    ["Col1", "Col2"],
+                    ["Data1", "Data2"]
+                ]
+            ]
+        ];
+        $expectedHtml = '<table class="table"> <tr> <td> Col1 </td> <td> Col2 </td> </tr> <tr> <td> Data1 </td> <td> Data2 </td> </tr> </table>';
+        $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
+        
+        // Act
+        $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
+
+        // Assert
+        $this->assertEquals($expectedHtml, $actualHtml);
+    }
+}

--- a/tests/Unit/RenderTest.php
+++ b/tests/Unit/RenderTest.php
@@ -7,7 +7,7 @@ use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
 class RenderTest extends TestCase
 {
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function render_test():void
     {
         $this->assertTrue(true);


### PR DESCRIPTION
This pull request standardizes and improves the CSS class naming conventions across all Editor.js block Blade templates. The changes ensure that each block uses a consistent `editorjs-*` class prefix, making it easier to style and maintain the blocks in the future.

**Accessibility and maintainability:**

* The use of descriptive and consistent class names improves maintainability and makes it easier to apply targeted styles or scripts to specific block elements. (applies to all changes above)

These updates collectively enhance the maintainability, scalability, and clarity of the block templates' structure and styling.

Closes #13 