### PR TITLE
[3.x] Add laravel pint for code linting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
 	},
 	"require-dev": {
 		"orchestra/testbench": "^8.36",
-		"phpunit/phpunit": "^10.5"
+		"phpunit/phpunit": "^10.5",
+		"laravel/pint": "^1.25"
 	},
 	"autoload": {
 		"psr-4": {

--- a/config/laravel_editorjs.php
+++ b/config/laravel_editorjs.php
@@ -1,23 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 return [
     'config' => [
         'tools' => [
             'paragraph' => [
                 'text' => [
-                    'type'        => 'string',
+                    'type' => 'string',
                     'allowedTags' => 'i,b,a[href],code[class],mark[class]',
                 ],
             ],
-            'header'    => [
-                'text'  => [
-                    'type'        => 'string',
+            'header' => [
+                'text' => [
+                    'type' => 'string',
                     'allowedTags' => 'a[href],mark[class]',
                 ],
                 'level' => [1, 2, 3, 4, 5, 6],
             ],
-            'list'      => [
-                'style'  => [
+            'list' => [
+                'style' => [
                     0 => 'ordered',
                     1 => 'unordered',
                 ],
@@ -25,35 +27,35 @@ return [
                     'type' => 'array',
                     'data' => [
                         '-' => [
-                            'type'        => 'string',
+                            'type' => 'string',
                             'allowedTags' => 'i,b,a[href],code[class],mark[class]',
                         ],
                     ],
                 ],
             ],
-            'linkTool'  => [
+            'linkTool' => [
                 'link' => 'string',
                 'meta' => [
                     'type' => 'array',
                     'data' => [
-                        'title'       => [
+                        'title' => [
                             'type' => 'string',
                         ],
                         'description' => [
                             'type' => 'string',
                         ],
-                        'url'         => [
-                            'type'     => 'string',
+                        'url' => [
+                            'type' => 'string',
                             'required' => false,
                         ],
-                        'domain'      => [
-                            'type'     => 'string',
+                        'domain' => [
+                            'type' => 'string',
                             'required' => false,
                         ],
-                        'image'       => [
-                            'type'     => 'array',
+                        'image' => [
+                            'type' => 'array',
                             'required' => false,
-                            'data'     => [
+                            'data' => [
                                 'url' => [
                                     'type' => 'string',
                                 ],
@@ -62,39 +64,39 @@ return [
                     ],
                 ],
             ],
-            'image'     => [
-                'file'           => [
+            'image' => [
+                'file' => [
                     'type' => 'array',
                     'data' => [
-                        'width'  => [
-                            'type'     => 'integer',
+                        'width' => [
+                            'type' => 'integer',
                             'required' => false,
                         ],
                         'height' => [
-                            'type'     => 'integer',
+                            'type' => 'integer',
                             'required' => false,
                         ],
-                        'url'    => 'string',
+                        'url' => 'string',
                     ],
                 ],
-                'caption'        => [
-                    'type'        => 'string',
+                'caption' => [
+                    'type' => 'string',
                     'allowedTags' => 'i,b,a[href],code[class],mark[class]',
                 ],
-                'withBorder'     => 'boolean',
+                'withBorder' => 'boolean',
                 'withBackground' => 'boolean',
-                'stretched'      => 'boolean',
+                'stretched' => 'boolean',
             ],
-            'table'     => [
+            'table' => [
                 'withHeadings' => 'boolean',
-                'content'      => [
+                'content' => [
                     'type' => 'array',
                     'data' => [
                         '-' => [
                             'type' => 'array',
                             'data' => [
                                 '-' => [
-                                    'type'        => 'string',
+                                    'type' => 'string',
                                     'allowedTags' => 'i,b,a[href],code[class],mark[class]',
                                 ],
                             ],
@@ -102,13 +104,13 @@ return [
                     ],
                 ],
             ],
-            'quote'     => [
-                'text'      => [
-                    'type'        => 'string',
+            'quote' => [
+                'text' => [
+                    'type' => 'string',
                     'allowedTags' => 'i,b,a[href],code[class],mark[class]',
                 ],
-                'caption'   => [
-                    'type'        => 'string',
+                'caption' => [
+                    'type' => 'string',
                     'allowedTags' => 'i,b,a[href],code[class],mark[class]',
                 ],
                 'alignment' => [
@@ -116,16 +118,16 @@ return [
                     1 => 'center',
                 ],
             ],
-            'code'      => [
+            'code' => [
                 'code' => [
-                    'type'        => 'string',
+                    'type' => 'string',
                     'allowedTags' => '*',
                 ],
             ],
             'delimiter' => [],
-            'raw'       => [
+            'raw' => [
                 'html' => [
-                    'type'        => 'string',
+                    'type' => 'string',
                     'allowedTags' => '*',
                 ],
             ],
@@ -160,10 +162,10 @@ return [
             // ]
             'embed' => [
                 'service' => 'string',
-                'source'  => 'string',
-                'embed'   => 'string',
-                'width'   => 'integer',
-                'height'  => 'integer',
+                'source' => 'string',
+                'embed' => 'string',
+                'width' => 'integer',
+                'height' => 'integer',
                 'caption' => 'string',
             ],
         ],

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,45 @@
+{
+    "preset": "laravel",
+    "rules": {
+        "declare_strict_types": true,
+        "concat_space": {
+            "spacing": "one"
+        },
+        "phpdoc_align": {
+            "align": "left",
+            "spacing": 1
+        },
+        "not_operator_with_successor_space": false,
+        "phpdoc_separation": {
+            "groups": [
+                [
+                    "deprecated",
+                    "link",
+                    "see",
+                    "since"
+                ],
+                [
+                    "author",
+                    "copyright",
+                    "license"
+                ],
+                [
+                    "category",
+                    "package",
+                    "subpackage"
+                ],
+                [
+                    "property",
+                    "property-read",
+                    "property-write"
+                ],
+                [
+                    "param"
+                ],
+                [
+                    "return"
+                ]
+            ]
+        }
+    }
+}

--- a/src/Facades/LaravelEditorJs.php
+++ b/src/Facades/LaravelEditorJs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AlAminFirdows\LaravelEditorJs\Facades;
 
 use Illuminate\Support\Facades\Facade;

--- a/src/LaravelEditorJs.php
+++ b/src/LaravelEditorJs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AlAminFirdows\LaravelEditorJs;
 
 use AlAminFirdows\LaravelEditorJs\Rules\EditorJsRule;
@@ -15,8 +17,6 @@ class LaravelEditorJs
     /**
      * Render blocks
      *
-     * @param string $data
-     * @return string
      * @throws Exception
      */
     public function render(string $data): string
@@ -30,7 +30,7 @@ class LaravelEditorJs
 
             foreach ($editor->getBlocks() as $block) {
 
-                $viewName = "laravel_editorjs::blocks." . Str::snake($block['type'], '-');
+                $viewName = 'laravel_editorjs::blocks.' . Str::snake($block['type'], '-');
 
                 if (!View::exists($viewName)) {
                     $viewName = 'laravel_editorjs::blocks.not-found';
@@ -38,7 +38,7 @@ class LaravelEditorJs
 
                 $renderedBlocks[] = View::make($viewName, [
                     'type' => $block['type'],
-                    'data' => $block['data']
+                    'data' => $block['data'],
                 ])->render();
             }
 
@@ -50,14 +50,11 @@ class LaravelEditorJs
 
     /**
      * Check if the data is valid
-     *
-     * @param string $data
-     * @return bool
      */
     public function isValid(string $data): bool
     {
         $validator = Validator::make(['data' => $data], [
-            'data' => ['required', 'string', new EditorJsRule]
+            'data' => ['required', 'string', new EditorJsRule],
         ]);
 
         if ($validator->passes()) {

--- a/src/LaravelEditorJsServiceProvider.php
+++ b/src/LaravelEditorJsServiceProvider.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AlAminFirdows\LaravelEditorJs;
 
-use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
 
 class LaravelEditorJsServiceProvider extends ServiceProvider
 {
@@ -44,6 +46,7 @@ class LaravelEditorJsServiceProvider extends ServiceProvider
          * Blade directive to render editor.js blocks.
          *
          * @param mixed $blocks The blocks of content to be rendered.
+         *
          * @return string Rendered HTML content.
          */
         Blade::directive('editorJsRender', function ($blocks) {

--- a/src/Rules/EditorJsRule.php
+++ b/src/Rules/EditorJsRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AlAminFirdows\LaravelEditorJs\Rules;
 
 use Closure;
@@ -12,12 +14,13 @@ class EditorJsRule implements ValidationRule
     /**
      * Run the validation rule.
      *
-     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @param \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString $fail
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if (!is_string($value)) {
             $fail('The :attribute must be a string.');
+
             return;
         }
 
@@ -26,11 +29,13 @@ class EditorJsRule implements ValidationRule
 
             if (json_last_error() !== JSON_ERROR_NONE) {
                 $fail('The :attribute must be a valid JSON string.');
+
                 return;
             }
 
             if (!isset($decodedData['blocks']) || !is_array($decodedData['blocks'])) {
                 $fail('The :attribute must contain a blocks array.');
+
                 return;
             }
 
@@ -45,8 +50,6 @@ class EditorJsRule implements ValidationRule
     /**
      * Handle EditorJS exceptions and call the fail closure with appropriate messages
      *
-     * @param EditorJSException $e
-     * @param array $blocks
      * @param Closure(string): void $fail
      */
     private function handleEditorJSException(EditorJSException $e, array $blocks, Closure $fail): void
@@ -58,7 +61,7 @@ class EditorJsRule implements ValidationRule
             $blockIndex = $this->findBlockIndex($blocks, $invalidTool);
 
             $fail("Block type '{$invalidTool}' is not supported" .
-                ($blockIndex !== null ? " (found in block {$blockIndex})" : ""));
+                ($blockIndex !== null ? " (found in block {$blockIndex})" : ''));
 
         } elseif (preg_match('/Not found required param `(.+)`/', $message, $matches)) {
             $missingParam = $matches[1];
@@ -89,10 +92,6 @@ class EditorJsRule implements ValidationRule
 
     /**
      * Find block index by type
-     *
-     * @param array $blocks
-     * @param string $type
-     * @return int|null
      */
     private function findBlockIndex(array $blocks, string $type): ?int
     {
@@ -101,15 +100,12 @@ class EditorJsRule implements ValidationRule
                 return $index;
             }
         }
+
         return null;
     }
 
     /**
      * Find parameter location in blocks
-     *
-     * @param array $blocks
-     * @param string $param
-     * @return array|null
      */
     private function findParameterLocation(array $blocks, string $param): ?array
     {
@@ -121,6 +117,7 @@ class EditorJsRule implements ValidationRule
                 ];
             }
         }
+
         return null;
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,8 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 use AlAminFirdows\LaravelEditorJs\LaravelEditorJs;
 
-if (! function_exists('editorjs')) {
+if (!function_exists('editorjs')) {
     /**
      * @return LaravelEditorJs
      */

--- a/tests/Feature/Blocks/ChecklistTest.php
+++ b/tests/Feature/Blocks/ChecklistTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
 
 use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
@@ -9,27 +11,27 @@ class ChecklistTest extends TestCase
     protected function getBlockData()
     {
         return [
-            "type" => "checklist",
-            "data" => [
-                "items" => [
+            'type' => 'checklist',
+            'data' => [
+                'items' => [
                     [
-                        "text" => "<a href=\"https://githuh.com/lmottasin\">LINK</a>",
-                        "checked" => true
+                        'text' => '<a href="https://githuh.com/lmottasin">LINK</a>',
+                        'checked' => true,
                     ],
                     [
-                        "text" => "<b>BOLD</b>",
-                        "checked" => false
+                        'text' => '<b>BOLD</b>',
+                        'checked' => false,
                     ],
                     [
-                        "text" => "<i>ITALIC</i>",
-                        "checked" => false
+                        'text' => '<i>ITALIC</i>',
+                        'checked' => false,
                     ],
                     [
-                        "text" => "PLAIN TEXT",
-                        "checked" => false
-                    ]
-                ]
-            ]
+                        'text' => 'PLAIN TEXT',
+                        'checked' => false,
+                    ],
+                ],
+            ],
         ];
 
     }
@@ -42,7 +44,7 @@ class ChecklistTest extends TestCase
     #[\PHPUnit\Framework\Attributes\Test]
     public function render_checklist_block_test(): void
     {
-        //This replaces any sequence of whitespace (including tabs and newlines) with a single space,
+        // This replaces any sequence of whitespace (including tabs and newlines) with a single space,
         // normalizing the formatting in both the expected and actual HTML strings.
 
         $expectedHtml = preg_replace('/\s+/', ' ', $this->getBlockHtml());

--- a/tests/Feature/Blocks/CodeTest.php
+++ b/tests/Feature/Blocks/CodeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
 
 use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
@@ -9,10 +11,10 @@ class CodeTest extends TestCase
     protected function getBlockData()
     {
         return [
-            "type" => "code",
-            "data" => [
-                "code" => "<?php\n\necho 'Hello World!';\n\n// This is a comment\nfunction test() {\n    return true;\n}"
-            ]
+            'type' => 'code',
+            'data' => [
+                'code' => "<?php\n\necho 'Hello World!';\n\n// This is a comment\nfunction test() {\n    return true;\n}",
+            ],
         ];
     }
 
@@ -26,7 +28,7 @@ class CodeTest extends TestCase
     {
         // Arrange
         $expectedHtml = preg_replace('/\s+/', ' ', $this->getBlockHtml());
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$this->getBlockData()])));
 
@@ -39,14 +41,14 @@ class CodeTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "code",
-            "data" => [
-                "code" => "<script>alert('XSS');</script>\n&amp; special chars"
-            ]
+            'type' => 'code',
+            'data' => [
+                'code' => "<script>alert('XSS');</script>\n&amp; special chars",
+            ],
         ];
-    $expectedHtml = '<div class="editorjs-code"> <code class="editorjs-code__content">&amp;lt;script&amp;gt;alert(&amp;#039;XSS&amp;#039;);&amp;lt;/script&amp;gt;&amp;amp;amp; special chars</code></div>';
+        $expectedHtml = '<div class="editorjs-code"> <code class="editorjs-code__content">&amp;lt;script&amp;gt;alert(&amp;#039;XSS&amp;#039;);&amp;lt;/script&amp;gt;&amp;amp;amp; special chars</code></div>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -59,14 +61,14 @@ class CodeTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "code",
-            "data" => [
-                "code" => ""
-            ]
+            'type' => 'code',
+            'data' => [
+                'code' => '',
+            ],
         ];
-    $expectedHtml = '<div class="editorjs-code"> <code class="editorjs-code__content"></code></div>';
+        $expectedHtml = '<div class="editorjs-code"> <code class="editorjs-code__content"></code></div>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 

--- a/tests/Feature/Blocks/DelimiterTest.php
+++ b/tests/Feature/Blocks/DelimiterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
 
 use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
@@ -9,8 +11,8 @@ class DelimiterTest extends TestCase
     protected function getBlockData()
     {
         return [
-            "type" => "delimiter",
-            "data" => []
+            'type' => 'delimiter',
+            'data' => [],
         ];
     }
 
@@ -24,7 +26,7 @@ class DelimiterTest extends TestCase
     {
         // Arrange
         $expectedHtml = preg_replace('/\s+/', ' ', $this->getBlockHtml());
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$this->getBlockData()])));
 
@@ -39,11 +41,11 @@ class DelimiterTest extends TestCase
         $blocks = [
             $this->getBlockData(),
             $this->getBlockData(),
-            $this->getBlockData()
+            $this->getBlockData(),
         ];
         $expectedHtml = str_repeat($this->getBlockHtml(), 3);
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData($blocks)));
 

--- a/tests/Feature/Blocks/EmbedBlockTest.php
+++ b/tests/Feature/Blocks/EmbedBlockTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
 
 use AlAminFirdows\LaravelEditorJs\Tests\TestCase;

--- a/tests/Feature/Blocks/HeaderTest.php
+++ b/tests/Feature/Blocks/HeaderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
 
 use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
@@ -9,11 +11,11 @@ class HeaderTest extends TestCase
     protected function getBlockData()
     {
         return [
-            "type" => "header",
-            "data" => [
-                "text" => "This is a Header",
-                "level" => 2
-            ]
+            'type' => 'header',
+            'data' => [
+                'text' => 'This is a Header',
+                'level' => 2,
+            ],
         ];
     }
 
@@ -27,7 +29,7 @@ class HeaderTest extends TestCase
     {
         // Arrange
         $expectedHtml = preg_replace('/\s+/', ' ', $this->getBlockHtml());
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$this->getBlockData()])));
 
@@ -40,15 +42,15 @@ class HeaderTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "header",
-            "data" => [
-                "text" => "Main Title",
-                "level" => 1
-            ]
+            'type' => 'header',
+            'data' => [
+                'text' => 'Main Title',
+                'level' => 1,
+            ],
         ];
-    $expectedHtml = '<h1 class="editorjs-header editorjs-header--level-1">Main Title</h1>';
+        $expectedHtml = '<h1 class="editorjs-header editorjs-header--level-1">Main Title</h1>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -61,15 +63,15 @@ class HeaderTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "header",
-            "data" => [
-                "text" => "Subtitle",
-                "level" => 3
-            ]
+            'type' => 'header',
+            'data' => [
+                'text' => 'Subtitle',
+                'level' => 3,
+            ],
         ];
-    $expectedHtml = '<h3 class="editorjs-header editorjs-header--level-3">Subtitle</h3>';
+        $expectedHtml = '<h3 class="editorjs-header editorjs-header--level-3">Subtitle</h3>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -82,15 +84,15 @@ class HeaderTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "header",
-            "data" => [
-                "text" => "Default Header",
-                "level" => 1
-            ]
+            'type' => 'header',
+            'data' => [
+                'text' => 'Default Header',
+                'level' => 1,
+            ],
         ];
-    $expectedHtml = '<h1 class="editorjs-header editorjs-header--level-1">Default Header</h1>';
+        $expectedHtml = '<h1 class="editorjs-header editorjs-header--level-1">Default Header</h1>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -103,15 +105,15 @@ class HeaderTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "header",
-            "data" => [
-                "text" => "",
-                "level" => 2
-            ]
+            'type' => 'header',
+            'data' => [
+                'text' => '',
+                'level' => 2,
+            ],
         ];
-    $expectedHtml = '<h2 class="editorjs-header editorjs-header--level-2"></h2>';
+        $expectedHtml = '<h2 class="editorjs-header editorjs-header--level-2"></h2>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 

--- a/tests/Feature/Blocks/ImageTest.php
+++ b/tests/Feature/Blocks/ImageTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
 
 use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
@@ -9,16 +11,16 @@ class ImageTest extends TestCase
     protected function getBlockData()
     {
         return [
-            "type" => "image",
-            "data" => [
-                "file" => [
-                    "url" => "https://example.com/image.jpg"
+            'type' => 'image',
+            'data' => [
+                'file' => [
+                    'url' => 'https://example.com/image.jpg',
                 ],
-                "caption" => "Sample image caption",
-                "withBorder" => false,
-                "stretched" => false,
-                "withBackground" => false
-            ]
+                'caption' => 'Sample image caption',
+                'withBorder' => false,
+                'stretched' => false,
+                'withBackground' => false,
+            ],
         ];
     }
 
@@ -32,7 +34,7 @@ class ImageTest extends TestCase
     {
         // Arrange
         $expectedHtml = preg_replace('/\s+/', ' ', $this->getBlockHtml());
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$this->getBlockData()])));
 
@@ -46,9 +48,9 @@ class ImageTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['withBorder'] = true;
-    $expectedHtml = '<figure class="editorjs-image editorjs-image--bordered"> <img class="editorjs-image__media" src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="editorjs-image__caption"> Sample image caption </footer> </figure>';
+        $expectedHtml = '<figure class="editorjs-image editorjs-image--bordered"> <img class="editorjs-image__media" src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="editorjs-image__caption"> Sample image caption </footer> </figure>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -62,9 +64,9 @@ class ImageTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['stretched'] = true;
-    $expectedHtml = '<figure class="editorjs-image editorjs-image--stretched"> <img class="editorjs-image__media" src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="editorjs-image__caption"> Sample image caption </footer> </figure>';
+        $expectedHtml = '<figure class="editorjs-image editorjs-image--stretched"> <img class="editorjs-image__media" src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="editorjs-image__caption"> Sample image caption </footer> </figure>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -78,9 +80,9 @@ class ImageTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['withBackground'] = true;
-    $expectedHtml = '<figure class="editorjs-image editorjs-image--backgrounded"> <img class="editorjs-image__media" src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="editorjs-image__caption"> Sample image caption </footer> </figure>';
+        $expectedHtml = '<figure class="editorjs-image editorjs-image--backgrounded"> <img class="editorjs-image__media" src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="editorjs-image__caption"> Sample image caption </footer> </figure>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -96,9 +98,9 @@ class ImageTest extends TestCase
         $blockData['data']['withBorder'] = true;
         $blockData['data']['stretched'] = true;
         $blockData['data']['withBackground'] = true;
-    $expectedHtml = '<figure class="editorjs-image editorjs-image--stretched editorjs-image--bordered editorjs-image--backgrounded"> <img class="editorjs-image__media" src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="editorjs-image__caption"> Sample image caption </footer> </figure>';
+        $expectedHtml = '<figure class="editorjs-image editorjs-image--stretched editorjs-image--bordered editorjs-image--backgrounded"> <img class="editorjs-image__media" src="https://example.com/image.jpg" alt="Sample image caption"> <footer class="editorjs-image__caption"> Sample image caption </footer> </figure>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -111,10 +113,10 @@ class ImageTest extends TestCase
     {
         // Arrange
         $blockData = $this->getBlockData();
-        $blockData['data']['caption'] = "";
-    $expectedHtml = '<figure class="editorjs-image "> <img class="editorjs-image__media" src="https://example.com/image.jpg" alt=""> </figure>';
+        $blockData['data']['caption'] = '';
+        $expectedHtml = '<figure class="editorjs-image "> <img class="editorjs-image__media" src="https://example.com/image.jpg" alt=""> </figure>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -128,9 +130,9 @@ class ImageTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['caption'] = '';
-    $expectedHtml = '<figure class="editorjs-image "> <img class="editorjs-image__media" src="https://example.com/image.jpg" alt=""> </figure>';
+        $expectedHtml = '<figure class="editorjs-image "> <img class="editorjs-image__media" src="https://example.com/image.jpg" alt=""> </figure>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 

--- a/tests/Feature/Blocks/LinkTest.php
+++ b/tests/Feature/Blocks/LinkTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
 
 use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
@@ -9,17 +11,17 @@ class LinkTest extends TestCase
     protected function getBlockData()
     {
         return [
-            "type" => "linkTool",
-            "data" => [
-                "link" => "https://example.com",
-                "meta" => [
-                    "title" => "Example Website",
-                    "description" => "This is an example website for testing purposes",
-                    "image" => [
-                        "url" => "https://example.com/image.jpg"
-                    ]
-                ]
-            ]
+            'type' => 'linkTool',
+            'data' => [
+                'link' => 'https://example.com',
+                'meta' => [
+                    'title' => 'Example Website',
+                    'description' => 'This is an example website for testing purposes',
+                    'image' => [
+                        'url' => 'https://example.com/image.jpg',
+                    ],
+                ],
+            ],
         ];
     }
 
@@ -33,7 +35,7 @@ class LinkTest extends TestCase
     {
         // Arrange
         $expectedHtml = preg_replace('/\s+/', ' ', $this->getBlockHtml());
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$this->getBlockData()])));
 
@@ -47,9 +49,9 @@ class LinkTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         unset($blockData['data']['meta']['image']);
-    $expectedHtml = '<a class="editorjs-link" href="https://example.com" target="_blank" rel="nofollow"> <div class="editorjs-link__title"> Example Website </div> <div class="editorjs-link__description"> This is an example website for testing purposes </div> <span class="editorjs-link__domain"> example.com </span></a>';
+        $expectedHtml = '<a class="editorjs-link" href="https://example.com" target="_blank" rel="nofollow"> <div class="editorjs-link__title"> Example Website </div> <div class="editorjs-link__description"> This is an example website for testing purposes </div> <span class="editorjs-link__domain"> example.com </span></a>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -63,9 +65,9 @@ class LinkTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['meta']['image']['url'] = '';
-    $expectedHtml = '<a class="editorjs-link" href="https://example.com" target="_blank" rel="nofollow"> <div class="editorjs-link__title"> Example Website </div> <div class="editorjs-link__description"> This is an example website for testing purposes </div> <span class="editorjs-link__domain"> example.com </span></a>';
+        $expectedHtml = '<a class="editorjs-link" href="https://example.com" target="_blank" rel="nofollow"> <div class="editorjs-link__title"> Example Website </div> <div class="editorjs-link__description"> This is an example website for testing purposes </div> <span class="editorjs-link__domain"> example.com </span></a>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -79,9 +81,9 @@ class LinkTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['link'] = 'https://blog.example.com/article';
-    $expectedHtml = '<a class="editorjs-link" href="https://blog.example.com/article" target="_blank" rel="nofollow"> <img class="editorjs-link__image" src="https://example.com/image.jpg"> <div class="editorjs-link__title"> Example Website </div> <div class="editorjs-link__description"> This is an example website for testing purposes </div> <span class="editorjs-link__domain"> blog.example.com </span></a>';
+        $expectedHtml = '<a class="editorjs-link" href="https://blog.example.com/article" target="_blank" rel="nofollow"> <img class="editorjs-link__image" src="https://example.com/image.jpg"> <div class="editorjs-link__title"> Example Website </div> <div class="editorjs-link__description"> This is an example website for testing purposes </div> <span class="editorjs-link__domain"> blog.example.com </span></a>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -94,18 +96,18 @@ class LinkTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "linkTool",
-            "data" => [
-                "link" => "https://minimal.com",
-                "meta" => [
-                    "title" => "Minimal Link",
-                    "description" => "Basic description"
-                ]
-            ]
+            'type' => 'linkTool',
+            'data' => [
+                'link' => 'https://minimal.com',
+                'meta' => [
+                    'title' => 'Minimal Link',
+                    'description' => 'Basic description',
+                ],
+            ],
         ];
-    $expectedHtml = '<a class="editorjs-link" href="https://minimal.com" target="_blank" rel="nofollow"> <div class="editorjs-link__title"> Minimal Link </div> <div class="editorjs-link__description"> Basic description </div> <span class="editorjs-link__domain"> minimal.com </span></a>';
+        $expectedHtml = '<a class="editorjs-link" href="https://minimal.com" target="_blank" rel="nofollow"> <div class="editorjs-link__title"> Minimal Link </div> <div class="editorjs-link__description"> Basic description </div> <span class="editorjs-link__domain"> minimal.com </span></a>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 

--- a/tests/Feature/Blocks/ListBlockTest.php
+++ b/tests/Feature/Blocks/ListBlockTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
 
 use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
@@ -22,7 +24,7 @@ class ListBlockTest extends TestCase
 
     protected function getBlockHtml()
     {
-        return "<ul class=\"editorjs-list editorjs-list--unordered\">        <li class=\"editorjs-list__item editorjs-list__item--odd\">Hello</li>        <li class=\"editorjs-list__item editorjs-list__item--even\">World</li>    </ul>";
+        return '<ul class="editorjs-list editorjs-list--unordered">        <li class="editorjs-list__item editorjs-list__item--odd">Hello</li>        <li class="editorjs-list__item editorjs-list__item--even">World</li>    </ul>';
     }
 
     #[\PHPUnit\Framework\Attributes\Test]

--- a/tests/Feature/Blocks/ListTest.php
+++ b/tests/Feature/Blocks/ListTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
 
 use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
@@ -9,15 +11,15 @@ class ListTest extends TestCase
     protected function getBlockData()
     {
         return [
-            "type" => "list",
-            "data" => [
-                "style" => "unordered",
-                "items" => [
-                    "First item",
-                    "Second item",
-                    "Third item"
-                ]
-            ]
+            'type' => 'list',
+            'data' => [
+                'style' => 'unordered',
+                'items' => [
+                    'First item',
+                    'Second item',
+                    'Third item',
+                ],
+            ],
         ];
     }
 
@@ -31,7 +33,7 @@ class ListTest extends TestCase
     {
         // Arrange
         $expectedHtml = preg_replace('/\s+/', ' ', $this->getBlockHtml());
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$this->getBlockData()])));
 
@@ -45,9 +47,9 @@ class ListTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['style'] = 'ordered';
-    $expectedHtml = '<ol class="editorjs-list editorjs-list--ordered"> <li class="editorjs-list__item editorjs-list__item--odd">First item</li> <li class="editorjs-list__item editorjs-list__item--even">Second item</li> <li class="editorjs-list__item editorjs-list__item--odd">Third item</li> </ol>';
+        $expectedHtml = '<ol class="editorjs-list editorjs-list--ordered"> <li class="editorjs-list__item editorjs-list__item--odd">First item</li> <li class="editorjs-list__item editorjs-list__item--even">Second item</li> <li class="editorjs-list__item editorjs-list__item--odd">Third item</li> </ol>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -60,18 +62,18 @@ class ListTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "list",
-            "data" => [
-                "style" => "ordered",
-                "items" => [
-                    "First item",
-                    "Second item"
-                ]
-            ]
+            'type' => 'list',
+            'data' => [
+                'style' => 'ordered',
+                'items' => [
+                    'First item',
+                    'Second item',
+                ],
+            ],
         ];
-    $expectedHtml = '<ol class="editorjs-list editorjs-list--ordered"> <li class="editorjs-list__item editorjs-list__item--odd">First item</li> <li class="editorjs-list__item editorjs-list__item--even">Second item</li> </ol>';
+        $expectedHtml = '<ol class="editorjs-list editorjs-list--ordered"> <li class="editorjs-list__item editorjs-list__item--odd">First item</li> <li class="editorjs-list__item editorjs-list__item--even">Second item</li> </ol>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -84,17 +86,17 @@ class ListTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "list",
-            "data" => [
-                "style" => "unordered",
-                "items" => [
-                    "Only item"
-                ]
-            ]
+            'type' => 'list',
+            'data' => [
+                'style' => 'unordered',
+                'items' => [
+                    'Only item',
+                ],
+            ],
         ];
-    $expectedHtml = '<ul class="editorjs-list editorjs-list--unordered"> <li class="editorjs-list__item editorjs-list__item--odd">Only item</li> </ul>';
+        $expectedHtml = '<ul class="editorjs-list editorjs-list--unordered"> <li class="editorjs-list__item editorjs-list__item--odd">Only item</li> </ul>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -107,15 +109,15 @@ class ListTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "list",
-            "data" => [
-                "style" => "unordered",
-                "items" => []
-            ]
+            'type' => 'list',
+            'data' => [
+                'style' => 'unordered',
+                'items' => [],
+            ],
         ];
-    $expectedHtml = '<ul class="editorjs-list editorjs-list--unordered"> </ul>';
+        $expectedHtml = '<ul class="editorjs-list editorjs-list--unordered"> </ul>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -128,19 +130,19 @@ class ListTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "list",
-            "data" => [
-                "style" => "unordered",
-                "items" => [
-                    "<b>Bold item</b>",
-                    "<i>Italic item</i>",
-                    "<a href=\"https://example.com\">Link item</a>"
-                ]
-            ]
+            'type' => 'list',
+            'data' => [
+                'style' => 'unordered',
+                'items' => [
+                    '<b>Bold item</b>',
+                    '<i>Italic item</i>',
+                    '<a href="https://example.com">Link item</a>',
+                ],
+            ],
         ];
-    $expectedHtml = '<ul class="editorjs-list editorjs-list--unordered"> <li class="editorjs-list__item editorjs-list__item--odd">&lt;b&gt;Bold item&lt;/b&gt;</li> <li class="editorjs-list__item editorjs-list__item--even">&lt;i&gt;Italic item&lt;/i&gt;</li> <li class="editorjs-list__item editorjs-list__item--odd">&lt;a href=&quot;https://example.com&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;Link item&lt;/a&gt;</li> </ul>';
+        $expectedHtml = '<ul class="editorjs-list editorjs-list--unordered"> <li class="editorjs-list__item editorjs-list__item--odd">&lt;b&gt;Bold item&lt;/b&gt;</li> <li class="editorjs-list__item editorjs-list__item--even">&lt;i&gt;Italic item&lt;/i&gt;</li> <li class="editorjs-list__item editorjs-list__item--odd">&lt;a href=&quot;https://example.com&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;Link item&lt;/a&gt;</li> </ul>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 

--- a/tests/Feature/Blocks/ParagraphBlockTest.php
+++ b/tests/Feature/Blocks/ParagraphBlockTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
 
 use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
@@ -18,7 +20,7 @@ class ParagraphBlockTest extends TestCase
 
     protected function getBlockHtml()
     {
-        return "<p class=\"editorjs-paragraph\">Hello world!</p>";
+        return '<p class="editorjs-paragraph">Hello world!</p>';
     }
 
     #[\PHPUnit\Framework\Attributes\Test]

--- a/tests/Feature/Blocks/ParagraphTest.php
+++ b/tests/Feature/Blocks/ParagraphTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
 
 use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
@@ -9,10 +11,10 @@ class ParagraphTest extends TestCase
     protected function getBlockData()
     {
         return [
-            "type" => "paragraph",
-            "data" => [
-                "text" => "This is a simple paragraph with some text content."
-            ]
+            'type' => 'paragraph',
+            'data' => [
+                'text' => 'This is a simple paragraph with some text content.',
+            ],
         ];
     }
 
@@ -26,7 +28,7 @@ class ParagraphTest extends TestCase
     {
         // Arrange
         $expectedHtml = preg_replace('/\s+/', ' ', $this->getBlockHtml());
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$this->getBlockData()])));
 
@@ -39,14 +41,14 @@ class ParagraphTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "paragraph",
-            "data" => [
-                "text" => "This paragraph contains <b>bold</b>, <i>italic</i>, and <a href=\"https://example.com\">link</a> elements."
-            ]
+            'type' => 'paragraph',
+            'data' => [
+                'text' => 'This paragraph contains <b>bold</b>, <i>italic</i>, and <a href="https://example.com">link</a> elements.',
+            ],
         ];
-    $expectedHtml = '<p class="editorjs-paragraph">This paragraph contains &lt;b&gt;bold&lt;/b&gt;, &lt;i&gt;italic&lt;/i&gt;, and &lt;a href=&quot;https://example.com&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;link&lt;/a&gt; elements.</p>';
+        $expectedHtml = '<p class="editorjs-paragraph">This paragraph contains &lt;b&gt;bold&lt;/b&gt;, &lt;i&gt;italic&lt;/i&gt;, and &lt;a href=&quot;https://example.com&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;link&lt;/a&gt; elements.</p>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -59,14 +61,14 @@ class ParagraphTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "paragraph",
-            "data" => [
-                "text" => ""
-            ]
+            'type' => 'paragraph',
+            'data' => [
+                'text' => '',
+            ],
         ];
-    $expectedHtml = '<p class="editorjs-paragraph"></p>';
+        $expectedHtml = '<p class="editorjs-paragraph"></p>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -79,14 +81,14 @@ class ParagraphTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "paragraph",
-            "data" => [
-                "text" => "This is line one\nThis is line two\nThis is line three"
-            ]
+            'type' => 'paragraph',
+            'data' => [
+                'text' => "This is line one\nThis is line two\nThis is line three",
+            ],
         ];
-    $expectedHtml = '<p class="editorjs-paragraph">This is line oneThis is line twoThis is line three</p>';
+        $expectedHtml = '<p class="editorjs-paragraph">This is line oneThis is line twoThis is line three</p>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -99,14 +101,14 @@ class ParagraphTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "paragraph",
-            "data" => [
-                "text" => "Special chars: &amp; &lt; &gt; &quot; &#39;"
-            ]
+            'type' => 'paragraph',
+            'data' => [
+                'text' => 'Special chars: &amp; &lt; &gt; &quot; &#39;',
+            ],
         ];
-    $expectedHtml = '<p class="editorjs-paragraph">Special chars: &amp;amp; &amp;lt; &amp;gt; &quot; &#039;</p>';
+        $expectedHtml = '<p class="editorjs-paragraph">Special chars: &amp;amp; &amp;lt; &amp;gt; &quot; &#039;</p>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -120,21 +122,21 @@ class ParagraphTest extends TestCase
         // Arrange
         $blocks = [
             [
-                "type" => "paragraph",
-                "data" => [
-                    "text" => "First paragraph"
-                ]
+                'type' => 'paragraph',
+                'data' => [
+                    'text' => 'First paragraph',
+                ],
             ],
             [
-                "type" => "paragraph",
-                "data" => [
-                    "text" => "Second paragraph"
-                ]
-            ]
+                'type' => 'paragraph',
+                'data' => [
+                    'text' => 'Second paragraph',
+                ],
+            ],
         ];
-    $expectedHtml = '<p class="editorjs-paragraph">First paragraph</p><p class="editorjs-paragraph">Second paragraph</p>';
+        $expectedHtml = '<p class="editorjs-paragraph">First paragraph</p><p class="editorjs-paragraph">Second paragraph</p>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData($blocks)));
 

--- a/tests/Feature/Blocks/QuoteTest.php
+++ b/tests/Feature/Blocks/QuoteTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
 
 use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
@@ -9,12 +11,12 @@ class QuoteTest extends TestCase
     protected function getBlockData()
     {
         return [
-            "type" => "quote",
-            "data" => [
-                "text" => "This is a quote text that demonstrates the quote block functionality.",
-                "caption" => "Quote Author",
-                "alignment" => "left"
-            ]
+            'type' => 'quote',
+            'data' => [
+                'text' => 'This is a quote text that demonstrates the quote block functionality.',
+                'caption' => 'Quote Author',
+                'alignment' => 'left',
+            ],
         ];
     }
 
@@ -28,7 +30,7 @@ class QuoteTest extends TestCase
     {
         // Arrange
         $expectedHtml = preg_replace('/\s+/', ' ', $this->getBlockHtml());
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$this->getBlockData()])));
 
@@ -42,9 +44,9 @@ class QuoteTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['alignment'] = 'center';
-    $expectedHtml = '<blockquote class="editorjs-quote"> <p class="editorjs-quote__text text-center">This is a quote text that demonstrates the quote block functionality.</p> <small class="editorjs-quote__caption text-center">— Quote Author</small> </blockquote>';
+        $expectedHtml = '<blockquote class="editorjs-quote"> <p class="editorjs-quote__text text-center">This is a quote text that demonstrates the quote block functionality.</p> <small class="editorjs-quote__caption text-center">— Quote Author</small> </blockquote>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -55,12 +57,12 @@ class QuoteTest extends TestCase
     #[\PHPUnit\Framework\Attributes\Test]
     public function render_quote_default_alignment_test(): void
     {
-        // Arrange  
+        // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['alignment'] = 'left'; // Test left alignment as default is not supported
-    $expectedHtml = '<blockquote class="editorjs-quote"> <p class="editorjs-quote__text text-left">This is a quote text that demonstrates the quote block functionality.</p> <small class="editorjs-quote__caption text-left">— Quote Author</small> </blockquote>';
+        $expectedHtml = '<blockquote class="editorjs-quote"> <p class="editorjs-quote__text text-left">This is a quote text that demonstrates the quote block functionality.</p> <small class="editorjs-quote__caption text-left">— Quote Author</small> </blockquote>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -73,10 +75,10 @@ class QuoteTest extends TestCase
     {
         // Arrange
         $blockData = $this->getBlockData();
-        $blockData['data']['caption'] = "";
-    $expectedHtml = '<blockquote class="editorjs-quote"> <p class="editorjs-quote__text text-left">This is a quote text that demonstrates the quote block functionality.</p> </blockquote>';
+        $blockData['data']['caption'] = '';
+        $expectedHtml = '<blockquote class="editorjs-quote"> <p class="editorjs-quote__text text-left">This is a quote text that demonstrates the quote block functionality.</p> </blockquote>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -90,15 +92,13 @@ class QuoteTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['caption'] = '';
-    $expectedHtml = '<blockquote class="editorjs-quote"> <p class="editorjs-quote__text text-left">This is a quote text that demonstrates the quote block functionality.</p> </blockquote>';
+        $expectedHtml = '<blockquote class="editorjs-quote"> <p class="editorjs-quote__text text-left">This is a quote text that demonstrates the quote block functionality.</p> </blockquote>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
         // Assert
         $this->assertEquals($expectedHtml, $actualHtml);
     }
-
-
 }

--- a/tests/Feature/Blocks/RawTest.php
+++ b/tests/Feature/Blocks/RawTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
 
 use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
@@ -9,10 +11,10 @@ class RawTest extends TestCase
     protected function getBlockData()
     {
         return [
-            "type" => "raw",
-            "data" => [
-                "html" => "<div class=\"custom-widget\">\n    <h3>Custom HTML Content</h3>\n    <p>This is raw HTML content.</p>\n</div>"
-            ]
+            'type' => 'raw',
+            'data' => [
+                'html' => "<div class=\"custom-widget\">\n    <h3>Custom HTML Content</h3>\n    <p>This is raw HTML content.</p>\n</div>",
+            ],
         ];
     }
 
@@ -26,7 +28,7 @@ class RawTest extends TestCase
     {
         // Arrange
         $expectedHtml = preg_replace('/\s+/', ' ', $this->getBlockHtml());
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$this->getBlockData()])));
 
@@ -39,14 +41,14 @@ class RawTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "raw",
-            "data" => [
-                "html" => "<script>console.log('Hello World!');</script>"
-            ]
+            'type' => 'raw',
+            'data' => [
+                'html' => "<script>console.log('Hello World!');</script>",
+            ],
         ];
-    $expectedHtml = '<div class="editorjs-raw" style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> &lt;script&gt;console.log(&#039;Hello World!&#039;);&lt;/script&gt;</div>';
+        $expectedHtml = '<div class="editorjs-raw" style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> &lt;script&gt;console.log(&#039;Hello World!&#039;);&lt;/script&gt;</div>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -59,14 +61,14 @@ class RawTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "raw",
-            "data" => [
-                "html" => "<iframe src=\"https://example.com\" width=\"100%\" height=\"400\"></iframe>"
-            ]
+            'type' => 'raw',
+            'data' => [
+                'html' => '<iframe src="https://example.com" width="100%" height="400"></iframe>',
+            ],
         ];
-    $expectedHtml = '<div class="editorjs-raw" style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> &lt;iframe src=&quot;https://example.com&quot; width=&quot;100%&quot; height=&quot;400&quot;&gt;&lt;/iframe&gt;</div>';
+        $expectedHtml = '<div class="editorjs-raw" style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> &lt;iframe src=&quot;https://example.com&quot; width=&quot;100%&quot; height=&quot;400&quot;&gt;&lt;/iframe&gt;</div>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -79,14 +81,14 @@ class RawTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "raw",
-            "data" => [
-                "html" => ""
-            ]
+            'type' => 'raw',
+            'data' => [
+                'html' => '',
+            ],
         ];
-    $expectedHtml = '<div class="editorjs-raw" style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> </div>';
+        $expectedHtml = '<div class="editorjs-raw" style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> </div>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -99,14 +101,14 @@ class RawTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "raw",
-            "data" => [
-                "html" => "Plain text content without HTML tags"
-            ]
+            'type' => 'raw',
+            'data' => [
+                'html' => 'Plain text content without HTML tags',
+            ],
         ];
-    $expectedHtml = '<div class="editorjs-raw" style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> Plain text content without HTML tags</div>';
+        $expectedHtml = '<div class="editorjs-raw" style="min-height: 200px; background-color: #1e2128; font-family: Menlo, Monaco, Consolas, Courier New, monospace; font-size: 14px; line-height: 1.6; letter-spacing: -0.2px; color: #e2e2e2; padding: 10px 12px;"> Plain text content without HTML tags</div>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 

--- a/tests/Feature/Blocks/TableTest.php
+++ b/tests/Feature/Blocks/TableTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AlAminFirdows\LaravelEditorJs\Tests\Feature\Blocks;
 
 use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
@@ -9,15 +11,15 @@ class TableTest extends TestCase
     protected function getBlockData()
     {
         return [
-            "type" => "table",
-            "data" => [
-                "withHeadings" => true,
-                "content" => [
-                    ["Name", "Age", "City"],
-                    ["John Doe", "30", "New York"],
-                    ["Jane Smith", "25", "Los Angeles"]
-                ]
-            ]
+            'type' => 'table',
+            'data' => [
+                'withHeadings' => true,
+                'content' => [
+                    ['Name', 'Age', 'City'],
+                    ['John Doe', '30', 'New York'],
+                    ['Jane Smith', '25', 'Los Angeles'],
+                ],
+            ],
         ];
     }
 
@@ -31,7 +33,7 @@ class TableTest extends TestCase
     {
         // Arrange
         $expectedHtml = preg_replace('/\s+/', ' ', $this->getBlockHtml());
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$this->getBlockData()])));
 
@@ -45,9 +47,9 @@ class TableTest extends TestCase
         // Arrange
         $blockData = $this->getBlockData();
         $blockData['data']['withHeadings'] = false;
-    $expectedHtml = '<table class="editorjs-table"> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> Name </td> <td class="editorjs-table__cell"> Age </td> <td class="editorjs-table__cell"> City </td> </tr> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> John Doe </td> <td class="editorjs-table__cell"> 30 </td> <td class="editorjs-table__cell"> New York </td> </tr> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> Jane Smith </td> <td class="editorjs-table__cell"> 25 </td> <td class="editorjs-table__cell"> Los Angeles </td> </tr> </table>';
+        $expectedHtml = '<table class="editorjs-table"> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> Name </td> <td class="editorjs-table__cell"> Age </td> <td class="editorjs-table__cell"> City </td> </tr> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> John Doe </td> <td class="editorjs-table__cell"> 30 </td> <td class="editorjs-table__cell"> New York </td> </tr> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> Jane Smith </td> <td class="editorjs-table__cell"> 25 </td> <td class="editorjs-table__cell"> Los Angeles </td> </tr> </table>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -60,17 +62,17 @@ class TableTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "table",
-            "data" => [
-                "withHeadings" => true,
-                "content" => [
-                    ["Header 1", "Header 2"]
-                ]
-            ]
+            'type' => 'table',
+            'data' => [
+                'withHeadings' => true,
+                'content' => [
+                    ['Header 1', 'Header 2'],
+                ],
+            ],
         ];
-    $expectedHtml = '<table class="editorjs-table"> <tr class="editorjs-table__row"> <th class="editorjs-table__cell"> Header 1 </th> <th class="editorjs-table__cell"> Header 2 </th> </tr> </table>';
+        $expectedHtml = '<table class="editorjs-table"> <tr class="editorjs-table__row"> <th class="editorjs-table__cell"> Header 1 </th> <th class="editorjs-table__cell"> Header 2 </th> </tr> </table>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -83,19 +85,19 @@ class TableTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "table",
-            "data" => [
-                "withHeadings" => false,
-                "content" => [
-                    ["A", "", "C"],
-                    ["", "E", ""],
-                    ["G", "H", "I"]
-                ]
-            ]
+            'type' => 'table',
+            'data' => [
+                'withHeadings' => false,
+                'content' => [
+                    ['A', '', 'C'],
+                    ['', 'E', ''],
+                    ['G', 'H', 'I'],
+                ],
+            ],
         ];
-    $expectedHtml = '<table class="editorjs-table"> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> A </td> <td class="editorjs-table__cell"> </td> <td class="editorjs-table__cell"> C </td> </tr> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> </td> <td class="editorjs-table__cell"> E </td> <td class="editorjs-table__cell"> </td> </tr> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> G </td> <td class="editorjs-table__cell"> H </td> <td class="editorjs-table__cell"> I </td> </tr> </table>';
+        $expectedHtml = '<table class="editorjs-table"> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> A </td> <td class="editorjs-table__cell"> </td> <td class="editorjs-table__cell"> C </td> </tr> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> </td> <td class="editorjs-table__cell"> E </td> <td class="editorjs-table__cell"> </td> </tr> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> G </td> <td class="editorjs-table__cell"> H </td> <td class="editorjs-table__cell"> I </td> </tr> </table>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -108,18 +110,18 @@ class TableTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "table",
-            "data" => [
-                "withHeadings" => true,
-                "content" => [
-                    ["<b>Bold Header</b>", "Normal Header"],
-                    ["<a href=\"#\">Link</a>", "<i>Italic text</i>"]
-                ]
-            ]
+            'type' => 'table',
+            'data' => [
+                'withHeadings' => true,
+                'content' => [
+                    ['<b>Bold Header</b>', 'Normal Header'],
+                    ['<a href="#">Link</a>', '<i>Italic text</i>'],
+                ],
+            ],
         ];
-    $expectedHtml = '<table class="editorjs-table"> <tr class="editorjs-table__row"> <th class="editorjs-table__cell"> &lt;b&gt;Bold Header&lt;/b&gt; </th> <th class="editorjs-table__cell"> Normal Header </th> </tr> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> &lt;a href=&quot;#&quot;&gt;Link&lt;/a&gt; </td> <td class="editorjs-table__cell"> &lt;i&gt;Italic text&lt;/i&gt; </td> </tr> </table>';
+        $expectedHtml = '<table class="editorjs-table"> <tr class="editorjs-table__row"> <th class="editorjs-table__cell"> &lt;b&gt;Bold Header&lt;/b&gt; </th> <th class="editorjs-table__cell"> Normal Header </th> </tr> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> &lt;a href=&quot;#&quot;&gt;Link&lt;/a&gt; </td> <td class="editorjs-table__cell"> &lt;i&gt;Italic text&lt;/i&gt; </td> </tr> </table>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -132,15 +134,15 @@ class TableTest extends TestCase
     {
         // Arrange
         $blockData = [
-            "type" => "table",
-            "data" => [
-                "withHeadings" => false,
-                "content" => []
-            ]
+            'type' => 'table',
+            'data' => [
+                'withHeadings' => false,
+                'content' => [],
+            ],
         ];
-    $expectedHtml = '<table class="editorjs-table"> </table>';
+        $expectedHtml = '<table class="editorjs-table"> </table>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 
@@ -149,22 +151,22 @@ class TableTest extends TestCase
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
-    public function render_table_with_default_withHeadings_test(): void
+    public function render_table_with_default_with_headings_test(): void
     {
         // Arrange
         $blockData = [
-            "type" => "table",
-            "data" => [
-                "withHeadings" => false,
-                "content" => [
-                    ["Col1", "Col2"],
-                    ["Data1", "Data2"]
-                ]
-            ]
+            'type' => 'table',
+            'data' => [
+                'withHeadings' => false,
+                'content' => [
+                    ['Col1', 'Col2'],
+                    ['Data1', 'Data2'],
+                ],
+            ],
         ];
-    $expectedHtml = '<table class="editorjs-table"> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> Col1 </td> <td class="editorjs-table__cell"> Col2 </td> </tr> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> Data1 </td> <td class="editorjs-table__cell"> Data2 </td> </tr> </table>';
+        $expectedHtml = '<table class="editorjs-table"> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> Col1 </td> <td class="editorjs-table__cell"> Col2 </td> </tr> <tr class="editorjs-table__row"> <td class="editorjs-table__cell"> Data1 </td> <td class="editorjs-table__cell"> Data2 </td> </tr> </table>';
         $expectedHtml = preg_replace('/\s+/', ' ', $expectedHtml);
-        
+
         // Act
         $actualHtml = preg_replace('/\s+/', ' ', $this->renderBlocks($this->getEditorData([$blockData])));
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AlAminFirdows\LaravelEditorJs\Tests;
 
 use AlAminFirdows\LaravelEditorJs\Facades\LaravelEditorJs;
@@ -17,9 +19,9 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     protected function getEditorData(array $blocks)
     {
         return json_encode([
-            'time'      => time(),
-            'blocks'    => $blocks,
-            'version'   => '2.28.0',
+            'time' => time(),
+            'blocks' => $blocks,
+            'version' => '2.28.0',
         ]);
     }
 

--- a/tests/Unit/RenderTest.php
+++ b/tests/Unit/RenderTest.php
@@ -1,14 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AlAminFirdows\LaravelEditorJs\Tests\Unit;
 
 use AlAminFirdows\LaravelEditorJs\Tests\TestCase;
 
 class RenderTest extends TestCase
 {
-
     #[\PHPUnit\Framework\Attributes\Test]
-    public function render_test():void
+    public function render_test(): void
     {
         $this->assertTrue(true);
     }


### PR DESCRIPTION
This pull request introduces code style improvements and enforces stricter typing across the codebase, mainly through the addition of the Laravel Pint code style tool and the use of `declare(strict_types=1);` in all PHP files. It also updates array syntax in tests and other files to use single quotes and trailing commas for consistency. These changes will help maintain code quality and prevent subtle type-related bugs.

**Code style enforcement:**

* Added `laravel/pint` as a dev dependency in `composer.json` and created a `pint.json` configuration file to enforce Laravel coding standards and custom rules.

**Strict typing:**

* Added `declare(strict_types=1);` to all PHP source, config, helper, and test files to enforce strict type checking.

**Array syntax and formatting consistency:**

* Updated array definitions in tests and core files to use single quotes and trailing commas, improving readability and consistency.

**Minor documentation and formatting improvements:**

* Improved docblock formatting and parameter alignment in several files for better clarity.
* Added blank lines for readability and consistency in validation logic and helper functions. 

These updates will make the codebase easier to maintain and less error-prone.