### PR TITLE
[3.x] Add larastan with level 6 checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
 	"require-dev": {
 		"orchestra/testbench": "^10.6",
 		"phpunit/phpunit": "^11.5",
-		"laravel/pint": "^1.25"
+		"laravel/pint": "^1.25",
+		"larastan/larastan": "^3.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,9 @@
+includes:
+    - vendor/larastan/larastan/extension.neon
+    - vendor/nesbot/carbon/extension.neon
+
+parameters:
+    paths:
+        - src/
+
+    level: 6

--- a/src/Rules/EditorJsRule.php
+++ b/src/Rules/EditorJsRule.php
@@ -14,7 +14,8 @@ class EditorJsRule implements ValidationRule
     /**
      * Run the validation rule.
      *
-     * @param \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString $fail
+     * @param \Closure $fail
+     * @phpstan-param \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString $fail
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
@@ -50,7 +51,8 @@ class EditorJsRule implements ValidationRule
     /**
      * Handle EditorJS exceptions and call the fail closure with appropriate messages
      *
-     * @param Closure(string): void $fail
+     * @param \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString $fail
+     * @param array<int, array<string, mixed>> $blocks
      */
     private function handleEditorJSException(EditorJSException $e, array $blocks, Closure $fail): void
     {
@@ -92,6 +94,8 @@ class EditorJsRule implements ValidationRule
 
     /**
      * Find block index by type
+     *
+     * @phpstan-param array<int, array<string, mixed>> $blocks
      */
     private function findBlockIndex(array $blocks, string $type): ?int
     {
@@ -106,6 +110,9 @@ class EditorJsRule implements ValidationRule
 
     /**
      * Find parameter location in blocks
+     *
+     * @phpstan-param array<int, array<string, mixed>> $blocks
+     * @phpstan-return array{blockIndex:int,blockType:string}|null
      */
     private function findParameterLocation(array $blocks, string $param): ?array
     {

--- a/src/Rules/EditorJsRule.php
+++ b/src/Rules/EditorJsRule.php
@@ -14,8 +14,7 @@ class EditorJsRule implements ValidationRule
     /**
      * Run the validation rule.
      *
-     * @param \Closure $fail
-     * @phpstan-param \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString $fail
+     * @param \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString $fail
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
@@ -95,7 +94,7 @@ class EditorJsRule implements ValidationRule
     /**
      * Find block index by type
      *
-     * @phpstan-param array<int, array<string, mixed>> $blocks
+     * @param array<int, array<string, mixed>> $blocks
      */
     private function findBlockIndex(array $blocks, string $type): ?int
     {
@@ -111,8 +110,8 @@ class EditorJsRule implements ValidationRule
     /**
      * Find parameter location in blocks
      *
-     * @phpstan-param array<int, array<string, mixed>> $blocks
-     * @phpstan-return array{blockIndex:int,blockType:string}|null
+     * @param array<int, array<string, mixed>> $blocks
+     * @return array{blockIndex:int,blockType:string}|null
      */
     private function findParameterLocation(array $blocks, string $param): ?array
     {


### PR DESCRIPTION
This pull request introduces improvements to static analysis and type safety by integrating Larastan and PHPStan configuration, and by adding and refining PHPStan type annotations in the `EditorJsRule` class. These changes help ensure stricter type checking and better code quality during development.

**Static analysis integration:**

* Added `larastan/larastan` to the `require-dev` dependencies in `composer.json` to enable PHPStan analysis for Laravel projects.
* Introduced a new `phpstan.neon` configuration file, specifying analysis paths, level, and including Larastan and Carbon extensions for enhanced static analysis.

**Type annotation improvements in `EditorJsRule`:**

* Updated method parameter annotations in `validate`, `handleEditorJSException`, `findBlockIndex`, and `findParameterLocation` to include PHPStan-specific type hints for closures and arrays, improving static type safety and documentation.