### PR TITLE
Support for new list structure

### DIFF
--- a/config/laravel_editorjs.php
+++ b/config/laravel_editorjs.php
@@ -25,8 +25,22 @@ return [
                     'type' => 'array',
                     'data' => [
                         '-' => [
-                            'type'        => 'string',
-                            'allowedTags' => 'i,b,a[href],code[class],mark[class]',
+                            'type' => 'array',
+                            'data' => [
+                                'content' => [
+                                    'type' => 'string',
+                                    'allowedTags' => 'i,b,a[href],code[class],mark[class]',
+                                ],
+                                'items' => [
+                                    'type' => 'array',
+                                    'data' => [
+                                        '-' => [
+                                            'type' => 'string',
+                                            'required' => false
+                                        ]
+                                    ]
+                                ]
+                            ]
                         ],
                     ],
                 ],

--- a/resources/views/blocks/list.blade.php
+++ b/resources/views/blocks/list.blade.php
@@ -5,6 +5,6 @@ $tag = $listType === 'unordered' ? 'ul' : 'ol';
 
 <{{ $tag }}>
     @foreach($data['items'] as $item)
-    <li>{{ $item }}</li>
+    <li>{{ array_key_exists('content', $item) ? $item['content'] : $item }}</li>
     @endforeach
 </{{ $tag }}>


### PR DESCRIPTION
The editorjs list block json output is updated.

new format

array:3 [▼
      "id" => "C_DSQo1FpC"
      "type" => "list"
      "data" => array:2 [▼
        "style" => "unordered"
        "items" => array:1 [▼
          0 => array:2 [▼
            "content" => "item 1"
            "items" => []
          ]
        ]
      ]
    ]
  ]

updated config and block view to match the new format