### PR TITLE
Laravel 13 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	"require": {
 		"php": "^8.1|^8.2|^8.3|^8.4",
 		"codex-team/editor.js": "v2.0.7",
-		"illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0"
+		"illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0"
 	},
 	"require-dev": {
 		"orchestra/testbench": "^8.36",


### PR DESCRIPTION
Laravel 13 was released, breaking changes seem to be minimal: https://laravel.com/docs/13.x/upgrade

I think, you only need to add version 13 as illuminate version. In my project with laravel 13 it is still working after that. 

@alaminfirdows Could you have a look? Thank you!